### PR TITLE
Address review feedback on brightness and logging

### DIFF
--- a/is_matrix_forge/led_matrix/controller/controller.py
+++ b/is_matrix_forge/led_matrix/controller/controller.py
@@ -385,7 +385,7 @@ class LEDMatrixController(metaclass=MultitonMeta):
             enable (bool, optional):
                 Whether to enable or disable animation. Defaults to True.
         """
-        from is_matrix_forge.led_matrix.display.helpers import animate
+        from is_matrix_forge.led_matrix.hardware import animate
 
         # Call the low-level animate function to control animation on the device
         # The animate function also sets the status to 'animate' when enabled
@@ -430,7 +430,7 @@ class LEDMatrixController(metaclass=MultitonMeta):
 
     @synchronized
     def draw_percentage(self, percentage: int, clear_first: bool = False):
-        from is_matrix_forge.led_matrix.display.helpers import percentage as _show_percentage_raw
+        from is_matrix_forge.led_matrix.hardware import percentage as _show_percentage_raw
         if not isinstance(percentage, int):
             if isinstance(percentage, (float, str)):
                 percentage = coerce_to_int(percentage)
@@ -562,7 +562,7 @@ class LEDMatrixController(metaclass=MultitonMeta):
             InvalidBrightnessError:
                 If the brightness value is invalid.
         """
-        from is_matrix_forge.led_matrix.display.helpers import brightness as _set_brightness_raw
+        from is_matrix_forge.led_matrix.hardware import brightness as _set_brightness_raw
         from is_matrix_forge.led_matrix.errors import InvalidBrightnessError
         from is_matrix_forge.common.helpers import \
             percentage_to_value  # Converts percentage values to raw hardware values

--- a/is_matrix_forge/led_matrix/display/animations/__init__.py
+++ b/is_matrix_forge/led_matrix/display/animations/__init__.py
@@ -1,6 +1,6 @@
 from time import sleep
 
-from is_matrix_forge.led_matrix.display.helpers import brightness
+from is_matrix_forge.led_matrix.hardware import brightness
 from is_matrix_forge.led_matrix.display.text import show_string
 
 

--- a/is_matrix_forge/led_matrix/display/effects/breather.py
+++ b/is_matrix_forge/led_matrix/display/effects/breather.py
@@ -1,6 +1,5 @@
 import threading
 import time
-import is_matrix_forge.led_matrix.display.helpers
 from is_matrix_forge.common.decorators import freeze_setter
 from is_matrix_forge.log_engine import ROOT_LOGGER, Loggable
 
@@ -51,22 +50,20 @@ class Breather(Loggable):
         self._step           = None
         self._fps            = None
 
-        self.controller      = controller
+        self.controller = controller
         log = self.class_logger
-        log.debug(f'Controller: {controller}')
-
         self.__initial_brightness = self.controller.brightness
-        log.debug(f'Initial brightness: {self.__initial_brightness}')
-
-        self.min_brightness  = min_brightness
-        self.max_brightness  = max_brightness
-        log.debug(f'Min brightness: {self.min_brightness} | Max brightness: {self.max_brightness}')
-
-        self.step            = step
-        log.debug(f'Step: {self.step}%')
-
-        self.fps             = breathe_fps
-        log.debug(f'FPS: {self.fps}')
+        self.min_brightness = min_brightness
+        self.max_brightness = max_brightness
+        self.step = step
+        self.fps = breathe_fps
+        log.debug(
+            "Breather initialized (min=%s max=%s step=%s fps=%s)",
+            self.min_brightness,
+            self.max_brightness,
+            self.step,
+            self.fps,
+        )
 
         self._breathing = False
         self._thread    = None
@@ -80,13 +77,9 @@ class Breather(Loggable):
         if not isinstance(new, bool):
             raise TypeError(f'"breathing" must be of type `bool`, not {type(new)}')
 
-        self.method_logger.debug(f'Received new value for "breathing": {new}')
-
         if self.breathing and not new:
-            self.method_logger.debug('Stopping breathing')
             self.stop()
         elif not self.breathing and new:
-            self.method_logger.debug('Starting breathing')
             self.start()
 
         self._breathing = new
@@ -105,8 +98,6 @@ class Breather(Loggable):
         from is_matrix_forge.led_matrix.controller.controller import LEDMatrixController
         if not isinstance(new, LEDMatrixController):
             raise TypeError(f'controller must be LEDMatrixController, not {type(new)}')
-
-        self.method_logger.debug(f'New controller: {new}')
 
         self._controller = new
 
@@ -135,8 +126,6 @@ class Breather(Loggable):
         if self._max_brightness is not None and new > self._max_brightness:
             raise ValueError('"min_brightness" must be <= max_brightness')
 
-        self.method_logger.debug(f'New min brightness: {new}')
-
         self._min_brightness = new
 
     @property
@@ -155,7 +144,6 @@ class Breather(Loggable):
         if self._min_brightness is not None and new < self._min_brightness:
             raise ValueError('"max_brightness" must be >= min_brightness')
 
-        self.method_logger.debug(f'New max brightness: {new}')
         self._max_brightness = new
 
     @property
@@ -172,8 +160,6 @@ class Breather(Loggable):
         if new <= 0 or new > 100:
             raise ValueError('"step" must be > 0 and <= 100')
 
-        self.method_logger.debug(f'New step: {new}')
-
         self._step = new
 
     @property
@@ -189,8 +175,6 @@ class Breather(Loggable):
             raise TypeError('"fps" must be a number')
         if new <= 0:
             raise ValueError('"fps" must be > 0')
-
-        self.method_logger.debug(f'New FPS: {new}')
 
         self._fps = float(new)
 

--- a/is_matrix_forge/led_matrix/display/helpers/__init__.py
+++ b/is_matrix_forge/led_matrix/display/helpers/__init__.py
@@ -26,7 +26,7 @@ def keep_image(
         time_between_refreshes: seconds to sleep after one full breath cycle
                                  (or between redraws if not breathing)
     """
-    base_brightness = brightness
+    base_brightness = controller.brightness
     t = 0.0
     period = 1.0  # one full sine cycle = 1 second
     step = 1.0 / breathe_fps
@@ -108,28 +108,10 @@ def render_matrix(dev, matrix):
     send_command(dev, CommandVals.Draw, vals)
 
 
-def brightness(dev, b: int):
-    """Adjust the brightness scaling of the entire screen."""
-    send_command(dev, CommandVals.Brightness, [b])
-
-
-def get_brightness(dev):
-    """Adjust the brightness scaling of the entire screen."""
-    res = send_command(dev, CommandVals.Brightness, with_response=True)
-    return int(res[0])
-
-
-def animate(dev, b: bool):
-    """Enable/disable animation"""
-    send_command(dev, CommandVals.Animate, [0x01 if b else 0x00])
-
-
-def get_animate(dev):
-    """Check if animation is enabled"""
-    res = send_command(dev, CommandVals.Animate, with_response=True)
-    return bool(res[0])
-
-
-def percentage(dev, p):
-    """Fill a percentage of the screen. Bottom to top"""
-    send_command(dev, CommandVals.Pattern, [PatternVals.Percentage, p])
+from is_matrix_forge.led_matrix.hardware import (
+    brightness,
+    get_brightness,
+    animate,
+    get_animate,
+    percentage,
+)

--- a/is_matrix_forge/led_matrix/hardware.py
+++ b/is_matrix_forge/led_matrix/hardware.py
@@ -131,4 +131,33 @@ def define_controllers(threaded=False):
 # CONTROLLERS = define_controllers()
 
 
+def brightness(dev, b: int):
+    """Adjust the brightness scaling of the entire screen."""
+    send_command(dev, CommandVals.Brightness, [b])
+
+
+def get_brightness(dev):
+    """Retrieve the current brightness value."""
+    res = send_command(dev, CommandVals.Brightness, with_response=True)
+    return int(res[0])
+
+
+def animate(dev, b: bool):
+    """Enable or disable animation."""
+    send_command(dev, CommandVals.Animate, [0x01 if b else 0x00])
+
+
+def get_animate(dev):
+    """Check if animation is enabled."""
+    res = send_command(dev, CommandVals.Animate, with_response=True)
+    return bool(res[0])
+
+
+def percentage(dev, p):
+    """Fill a percentage of the screen from bottom to top."""
+    from is_matrix_forge.inputmodule import PatternVals
+
+    send_command(dev, CommandVals.Pattern, [PatternVals.Percentage, p])
+
+
 

--- a/is_matrix_forge/monitor/gui/windows/main/__init__.py
+++ b/is_matrix_forge/monitor/gui/windows/main/__init__.py
@@ -1,6 +1,6 @@
 from .layout import Layout as MainWindowLayout
 from ..base import WindowBase
-from is_matrix_forge.led_matrix.display.helpers import brightness
+from is_matrix_forge.led_matrix.hardware import brightness
 from is_matrix_forge.led_matrix.helpers.device import DEVICES
 from is_matrix_forge.monitor.monitor import PowerMonitor
 import time

--- a/is_matrix_forge/monitor/monitor.py
+++ b/is_matrix_forge/monitor/monitor.py
@@ -8,8 +8,6 @@ from typing import Optional, Union
 from inspy_logger import Loggable
 from inspyre_toolbox.syntactic_sweets.classes import validate_type
 from serial.tools.list_ports_common import ListPortInfo
-
-import is_matrix_forge.led_matrix.display.helpers
 from is_matrix_forge.common.helpers import percentage_to_value
 from is_matrix_forge.led_matrix import pattern, get_animate, animate, percentage, LEDMatrixController
 from is_matrix_forge.led_matrix.display.animations import goodbye_animation
@@ -57,7 +55,9 @@ class PowerMonitor(Loggable):
         if unplugged_alert:
             self.unplugged_alert = unplugged_alert
 
-        is_matrix_forge.led_matrix.display.helpers.brightness = percentage_to_value(5)
+        # Initialize the LED matrix brightness to a low value.
+        # The controller API expects a percentage between 0 and 100.
+        self.controller.set_brightness(5)
         self.__battery_check_interval = battery_check_interval or self.DEFAULT_CHECK_INTERVAL
 
     @property


### PR DESCRIPTION
## Summary
- fix monitor brightness to use controller API
- centralize hardware commands in `led_matrix.hardware`
- trim debug logging in the Breather effect
- update imports to new hardware helpers

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'serial')*

------
https://chatgpt.com/codex/tasks/task_e_685a2ea1e4f4832db0ba9b494ca3bc95

## Summary by Sourcery

Centralize hardware interactions into a new module, update controller and monitor code to use the new hardware helpers for brightness, animation, and percentage commands, and trim redundant debug logs in the Breather effect

Enhancements:
- Centralize low-level hardware commands into dedicated functions in led_matrix.hardware
- Streamline Breather effect logging by consolidating debug statements
- Replace display.helpers imports with hardware module helpers for animation, brightness, and percentage control