### PR TITLE
Fix breather pausing in threading helpers

### DIFF
--- a/is_matrix_forge/led_matrix/controller/helpers/threading.py
+++ b/is_matrix_forge/led_matrix/controller/helpers/threading.py
@@ -29,9 +29,13 @@ def get_breather_context(self, pause_breather):
         return None
     breather = getattr(self, "breather", None)
     if breather and hasattr(breather, "paused"):
-        return breather.paused
+        pause_ctx = breather.paused
+        return pause_ctx() if callable(pause_ctx) else pause_ctx
 
-    return getattr(self, "breather_paused", None)
+    breather_paused = getattr(self, "breather_paused", None)
+    if callable(breather_paused):
+        return breather_paused()
+    return breather_paused
 
 
 def should_warn_thread_misuse(self_obj):
@@ -94,7 +98,7 @@ def run_with_contexts(ctx, lock, func):
             The return value of the called function.
     """
     if ctx is not None:
-        with ctx():
+        with ctx:
             if lock:
                 with lock:
                     return func()

--- a/tests/test_threading.py
+++ b/tests/test_threading.py
@@ -1,0 +1,67 @@
+import contextlib
+import threading
+import types
+import sys
+import importlib.util
+from pathlib import Path
+
+# Provide a minimal is_matrix_forge.log_engine so the helper module can import it
+log_engine = types.ModuleType("is_matrix_forge.log_engine")
+class DummyLogger:
+    def get_child(self, name):
+        return self
+    def warning(self, *a, **kw):
+        pass
+ROOT_LOGGER = DummyLogger()
+log_engine.ROOT_LOGGER = ROOT_LOGGER
+pkg = types.ModuleType("is_matrix_forge")
+pkg.log_engine = log_engine
+sys.modules["is_matrix_forge"] = pkg
+sys.modules["is_matrix_forge.log_engine"] = log_engine
+
+# Load the threading helper module directly from its path
+spec = importlib.util.spec_from_file_location(
+    "threading_helpers",
+    Path(__file__).resolve().parents[1] / "is_matrix_forge/led_matrix/controller/helpers/threading.py",
+)
+threading_helpers = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(threading_helpers)
+
+synchronized = threading_helpers.synchronized
+
+
+class DummyBreather:
+    def __init__(self):
+        self.pause_count = 0
+
+    @property
+    def paused(self):
+        @contextlib.contextmanager
+        def _ctx():
+            self.pause_count += 1
+            try:
+                yield
+            finally:
+                self.pause_count -= 1
+        return _ctx
+
+
+class DummyController:
+    def __init__(self):
+        self.breather = DummyBreather()
+        self._cmd_lock = threading.RLock()
+        self._thread_safe = True
+        self._warn_on_thread_misuse = False
+        self._owner_thread_id = threading.get_ident()
+
+    @synchronized
+    def check_pause(self):
+        return self.breather.pause_count
+
+
+def test_synchronized_pauses_breather():
+    ctrl = DummyController()
+    assert ctrl.breather.pause_count == 0
+    inside_count = ctrl.check_pause()
+    assert inside_count == 1
+    assert ctrl.breather.pause_count == 0


### PR DESCRIPTION
## Summary
- ensure `get_breather_context` returns an actual context manager
- run context manager directly in `run_with_contexts`
- add regression test for `synchronized` decorator pausing breather

## Testing
- `PYTHONPATH=. pytest tests/test_threading.py`
- `PYTHONPATH=. pytest` *(fails: ImportError: libGL.so.1: cannot open shared object file)*

------
https://chatgpt.com/codex/tasks/task_e_688e7591c898832d8fabcc81dfd12977

## Summary by Sourcery

Fix breather pausing logic in threading helpers and add a regression test for the synchronized decorator.

Bug Fixes:
- Ensure get_breather_context returns an actual context manager by calling callable attributes
- Update run_with_contexts to use the context manager directly instead of invoking it
- Fix synchronized decorator to properly pause and resume the breather during execution

Tests:
- Add regression test to verify that synchronized decorator pauses the breather count within its context