### PR TITLE
Add audio visualizer animation class

### DIFF
--- a/is_matrix_forge/led_matrix/display/grid/grid.py
+++ b/is_matrix_forge/led_matrix/display/grid/grid.py
@@ -76,10 +76,13 @@ class Grid:
         """
         self._grid = []
         if init_grid is not None:
-            # Try to detect if row-major was given by mistake
+            # Try to detect if row-major was given by mistake. Only transpose
+            # when the data does *not* already validate as column-major. This
+            # avoids corrupting square grids that are already in the correct
+            # orientation.
             if len(init_grid) == height and len(init_grid[0]) == width:
-                # row-major, convert to column-major
-                init_grid = [[row[x] for row in init_grid] for x in range(width)]
+                if not is_valid_grid(init_grid, width, height):
+                    init_grid = [[row[x] for row in init_grid] for x in range(width)]
             if not is_valid_grid(init_grid, width, height):
                 raise ValueError(f"init_grid must be {width}×{height} column-major 0/1 list")
             self._grid = [col[:] for col in init_grid]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,12 @@
+import json
+from pathlib import Path
+
+from platformdirs import PlatformDirs
+
+
+def pytest_configure():
+    dirs = PlatformDirs("IS-Matrix-Forge", "Inspyre Softworks")
+    mem_file = Path(dirs.user_data_path) / "memory.ini"
+    mem_file.parent.mkdir(parents=True, exist_ok=True)
+    mem_file.write_text(json.dumps({"first_run": False}))
+

--- a/tests/test_audio_visualizer_animation.py
+++ b/tests/test_audio_visualizer_animation.py
@@ -1,0 +1,18 @@
+import pytest
+
+from is_matrix_forge.led_matrix.display.animations.audio_visualizer import (
+    AudioVisualizerAnimation,
+)
+
+
+def test_play_requires_sounddevice():
+    vis = AudioVisualizerAnimation()
+    with pytest.raises(RuntimeError, match="sounddevice is required"):
+        vis.play([])
+
+
+def test_stop_without_start():
+    vis = AudioVisualizerAnimation()
+    # should not raise even if not started
+    vis.stop()
+

--- a/tests/test_grid.py
+++ b/tests/test_grid.py
@@ -248,7 +248,7 @@ def test_draw_draw_grid_not_callable():
     "x,y,expected",
     [
         (0, 0, 1),
-        (1, 1, 0),
+        (1, 1, 1),
     ],
     ids=["top_left", "bottom_right"]
 )
@@ -286,9 +286,9 @@ def test_get_pixel_value_out_of_bounds(x, y):
         # No shift
         ([[1, 0], [0, 1]], 0, 0, False, [[1, 0], [0, 1]]),
         # Shift right by 1, no wrap
-        ([[1, 0], [0, 1]], 1, 0, False, [[0, 0], [1, 1]]),
+        ([[1, 0], [0, 1]], 1, 0, False, [[0, 0], [1, 0]]),
         # Shift down by 1, no wrap
-        ([[1, 0], [0, 1]], 0, 1, False, [[0, 0], [1, 0]]),
+        ([[1, 0], [0, 1]], 0, 1, False, [[0, 1], [0, 0]]),
         # Shift left by 1, wrap
         ([[1, 0], [0, 1]], -1, 0, True, [[0, 1], [1, 0]]),
         # Shift up by 1, wrap


### PR DESCRIPTION
## Summary
- add `AudioVisualizerAnimation` so controllers can run a real-time audio bar display
- fix grid initialization from incorrectly transposing square grids
- adjust tests and add coverage for the audio visualizer

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688fd7af25b4832db654ec5e44fa3620

## Summary by Sourcery

Implement a new audio visualizer animation class, fix grid initialization logic, update the audio visualizer API, and expand test coverage

New Features:
- Add AudioVisualizerAnimation class for real-time audio bar visualization with backward-compatible alias

Bug Fixes:
- Prevent incorrect transposition of square grids in grid initialization
- Correct expected outcomes in grid shift and pixel retrieval tests

Enhancements:
- Revamp AudioVisualizer API to use `play`/`stop` with an `is_playing` flag and support dynamic controller assignment

Tests:
- Add tests for AudioVisualizerAnimation play/stop behavior
- Introduce pytest fixture for memory file setup