### PR TITLE
Prevent breather thread from self-joining

### DIFF
--- a/is_matrix_forge/led_matrix/controller/controller.py
+++ b/is_matrix_forge/led_matrix/controller/controller.py
@@ -64,6 +64,16 @@ class _BreatherPauseCtx:
 
         """
         if getattr(self.controller, "breathing", False):
+            # If we're already in the breather's own thread, do nothing to
+            # avoid stopping and joining the thread from within itself.
+            breather_thread = getattr(
+                getattr(self.controller, "breather", None),
+                "_thread",
+                None,
+            )
+            if breather_thread is threading.current_thread():
+                return
+
             self._was_breathing = True
             self.controller.breathing = False
             sleep(0.05)  # Required short delay to ensure hardware settles

--- a/is_matrix_forge/led_matrix/display/effects/breather.py
+++ b/is_matrix_forge/led_matrix/display/effects/breather.py
@@ -235,7 +235,8 @@ class Breather(Loggable):
         """
         self._breathing = False
         if self._thread:
-            self._thread.join()
+            if threading.current_thread() is not self._thread:
+                self._thread.join()
             self._thread = None
 
         self.method_logger.debug('Breathing effect stopped')


### PR DESCRIPTION
## Summary
- avoid pausing the breather when brightness updates originate from its own thread
- skip joining the breather thread when stopping from the same thread to prevent runtime errors

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'inspyre_toolbox.syntactic_sweets.classes')*

------
https://chatgpt.com/codex/tasks/task_e_68a126db4eb8832db4a7cb9e97a5bc9e

## Summary by Sourcery

Prevent the breather thread from self-joining or being paused by its own context manager to avoid runtime errors when brightness updates originate from that thread

Bug Fixes:
- Prevent the breather thread from pausing itself in the controller context
- Avoid joining the breather thread when stopping from within the same thread to prevent runtime errors