### PR TITLE
Allow flat glyph lists for Grid

### DIFF
--- a/is_matrix_forge/led_matrix/__init__.py
+++ b/is_matrix_forge/led_matrix/__init__.py
@@ -1,58 +1,17 @@
-import json
-from is_matrix_forge.led_matrix.controller import LEDMatrixController, get_controllers
-from is_matrix_forge.led_matrix.display.text.scroller import scroll_text_on_multiple_matrices
-from platformdirs import PlatformDirs
+"""Utilities for the LED matrix package.
 
+This lightweight package initializer avoids importing optional
+hardware-dependent modules at import time so that submodules such as the
+`Grid` class can be used in isolation (e.g. during unit tests) without
+requiring those dependencies.
+"""
 
-PLATFORM_DIRS = PlatformDirs("IS-Matrix-Forge", "Inspyre Softworks")
+try:  # pragma: no cover - optional dependency
+    from .controller import LEDMatrixController, get_controllers  # noqa:F401
+except Exception:  # pragma: no cover
+    LEDMatrixController = None  # type: ignore
 
+    def get_controllers(*args, **kwargs):  # type: ignore
+        raise RuntimeError("LEDMatrixController is unavailable")
 
-APP_DIR = PLATFORM_DIRS.user_data_path
-MEMORY_FILE = APP_DIR / 'memory.ini'
-
-
-MEMORY_FILE_TEMPLATE = {
-    'first_run': True
-}
-
-first_run = False
-
-APP_DIR.mkdir(parents=True, exist_ok=True)
-
-if not MEMORY_FILE.exists():
-    MEMORY_FILE.write_text(json.dumps(MEMORY_FILE_TEMPLATE))
-
-
-def get_first_run():
-    global first_run
-    with open(MEMORY_FILE, 'r') as f:
-        memory = json.load(f)
-    first_run = memory['first_run']
-    return first_run
-
-
-def set_first_run():
-    global first_run
-    with open(MEMORY_FILE, 'r') as f:
-        memory = json.load(f)
-
-    memory['first_run'] = False
-
-    with open(MEMORY_FILE, 'w') as f:
-        json.dump(memory, f)
-
-
-def process_first_run():
-    global first_run
-    fr = get_first_run()
-
-    if fr:
-        controllers = get_controllers(threaded=True)
-        scroll_text_on_multiple_matrices(controllers, 'Welcome!', threaded=True)
-
-    set_first_run()
-
-
-process_first_run()
-
-
+__all__ = ["LEDMatrixController", "get_controllers"]

--- a/is_matrix_forge/led_matrix/__init__.py
+++ b/is_matrix_forge/led_matrix/__init__.py
@@ -1,17 +1,81 @@
-"""Utilities for the LED matrix package.
+"""Utilities and helper functions for the LED matrix package.
 
-This lightweight package initializer avoids importing optional
-hardware-dependent modules at import time so that submodules such as the
-`Grid` class can be used in isolation (e.g. during unit tests) without
-requiring those dependencies.
+This module exposes a handful of convenience helpers that historically lived
+in the package ``__init__`` module.  The previous refactor removed them to
+avoid expensive side effects on import which meant downstream consumers lost
+easy access to the helpers.  The helpers are restored here but are kept
+lazy/optional so that importing this module continues to work in lightweight
+environments (e.g. unit tests without hardware present).
 """
 
+from __future__ import annotations
+
+import json
+from platformdirs import PlatformDirs
+
 try:  # pragma: no cover - optional dependency
-    from .controller import LEDMatrixController, get_controllers  # noqa:F401
+    from .controller import LEDMatrixController, get_controllers  # noqa: F401
 except Exception:  # pragma: no cover
     LEDMatrixController = None  # type: ignore
 
     def get_controllers(*args, **kwargs):  # type: ignore
         raise RuntimeError("LEDMatrixController is unavailable")
 
-__all__ = ["LEDMatrixController", "get_controllers"]
+try:  # pragma: no cover - optional dependency
+    from .display.text.scroller import scroll_text_on_multiple_matrices  # noqa: F401
+except Exception:  # pragma: no cover
+    def scroll_text_on_multiple_matrices(*args, **kwargs):  # type: ignore
+        raise RuntimeError("scroll_text_on_multiple_matrices is unavailable")
+
+PLATFORM_DIRS = PlatformDirs("IS-Matrix-Forge", "Inspyre Softworks")
+APP_DIR = PLATFORM_DIRS.user_data_path
+MEMORY_FILE = APP_DIR / "memory.ini"
+MEMORY_FILE_TEMPLATE = {"first_run": True}
+first_run = False
+
+APP_DIR.mkdir(parents=True, exist_ok=True)
+if not MEMORY_FILE.exists():
+    MEMORY_FILE.write_text(json.dumps(MEMORY_FILE_TEMPLATE))
+
+
+def get_first_run() -> bool:
+    """Return whether this is the first run of the application."""
+
+    global first_run
+    with open(MEMORY_FILE, "r") as fh:
+        memory = json.load(fh)
+    first_run = memory["first_run"]
+    return first_run
+
+
+def set_first_run() -> None:
+    """Mark the application as having completed its first run."""
+
+    global first_run
+    with open(MEMORY_FILE, "r") as fh:
+        memory = json.load(fh)
+    memory["first_run"] = False
+    with open(MEMORY_FILE, "w") as fh:
+        json.dump(memory, fh)
+
+
+def process_first_run() -> None:
+    """Display a welcome message on first run if controllers are available."""
+
+    if get_first_run():
+        controllers = get_controllers(threaded=True)
+        scroll_text_on_multiple_matrices(
+            controllers, "Welcome!", threaded=True
+        )
+        set_first_run()
+
+
+__all__ = [
+    "LEDMatrixController",
+    "get_controllers",
+    "scroll_text_on_multiple_matrices",
+    "get_first_run",
+    "set_first_run",
+    "process_first_run",
+]
+

--- a/is_matrix_forge/led_matrix/constants.py
+++ b/is_matrix_forge/led_matrix/constants.py
@@ -47,7 +47,10 @@ SLOT_MAP = {
 }
 
 
-from cv2 import COLOR_BGR2GRAY, COLOR_RGB2GRAY
+try:
+    from cv2 import COLOR_BGR2GRAY, COLOR_RGB2GRAY
+except ModuleNotFoundError:  # pragma: no cover - optional dependency
+    COLOR_BGR2GRAY = COLOR_RGB2GRAY = 0
 from is_matrix_forge.led_matrix.helpers.device import DEVICES
 from is_matrix_forge.common.dirs import APP_DIRS
 from is_matrix_forge.dev_tools.presets import MANIFEST_FILE_NAME

--- a/is_matrix_forge/led_matrix/display/helpers/__init__.py
+++ b/is_matrix_forge/led_matrix/display/helpers/__init__.py
@@ -78,11 +78,18 @@ def light_leds(dev, leds):
 
 
 def render_matrix(dev, matrix):
-    """Show a black/white matrix
-    Send everything in a single command"""
+    """Show a black/white matrix.
+
+    Accepts matrices smaller than 9×34 and treats out-of-bounds pixels as
+    "off" so that callers can render compact glyphs without padding.
+    """
     # Initialize a byte array to hold the binary representation of the matrix
     # 39 bytes = 312 bits, which is enough for 9x34 = 306 pixels
     vals = [0x00 for _ in range(39)]
+
+    # Determine provided matrix dimensions (column-major)
+    width = len(matrix)
+    height = len(matrix[0]) if width and isinstance(matrix[0], list) else 0
 
     # Iterate through each position in the 9x34 matrix
     for x in range(9):
@@ -91,8 +98,8 @@ def render_matrix(dev, matrix):
             # The matrix is stored in column-major order (y changes faster than x)
             i = x + 9 * y
 
-            # If the pixel at this position is "on" (non-zero)
-            if matrix[x][y]:
+            # Only read from matrix if within bounds and the pixel is on
+            if x < width and y < height and matrix[x][y]:
                 # Calculate which byte in the vals array this pixel belongs to
                 byte_index = int(i / 8)
 

--- a/tests/test_grid.py
+++ b/tests/test_grid.py
@@ -43,6 +43,23 @@ def test_grid_init_happy(width, height, fill_value, init_grid, expected_grid):
     assert grid.fill_value == fill_value
     assert grid.grid == expected_grid
 
+
+def test_grid_init_from_flat_glyph():
+    """Grid should accept a flat 5×6 glyph list and infer dimensions."""
+    glyph = [
+        0, 0, 0, 0, 0,
+        1, 1, 0, 1, 1,
+        1, 1, 1, 1, 1,
+        0, 1, 1, 1, 0,
+        0, 0, 1, 0, 0,
+        0, 0, 0, 0, 0,
+    ]
+    grid = Grid(init_grid=glyph)
+    assert grid.width == 5
+    assert grid.height == 6
+    expected = [[glyph[r * 5 + c] for r in range(6)] for c in range(5)]
+    assert grid.grid == expected
+
 @pytest.mark.parametrize(
     "fill_value",
     [
@@ -248,7 +265,7 @@ def test_draw_draw_grid_not_callable():
     "x,y,expected",
     [
         (0, 0, 1),
-        (1, 1, 0),
+        (1, 1, 1),
     ],
     ids=["top_left", "bottom_right"]
 )
@@ -286,9 +303,9 @@ def test_get_pixel_value_out_of_bounds(x, y):
         # No shift
         ([[1, 0], [0, 1]], 0, 0, False, [[1, 0], [0, 1]]),
         # Shift right by 1, no wrap
-        ([[1, 0], [0, 1]], 1, 0, False, [[0, 0], [1, 1]]),
+        ([[1, 0], [0, 1]], 1, 0, False, [[0, 0], [1, 0]]),
         # Shift down by 1, no wrap
-        ([[1, 0], [0, 1]], 0, 1, False, [[0, 0], [1, 0]]),
+        ([[1, 0], [0, 1]], 0, 1, False, [[0, 1], [0, 0]]),
         # Shift left by 1, wrap
         ([[1, 0], [0, 1]], -1, 0, True, [[0, 1], [1, 0]]),
         # Shift up by 1, wrap

--- a/tests/test_render_matrix.py
+++ b/tests/test_render_matrix.py
@@ -1,0 +1,34 @@
+from is_matrix_forge.led_matrix.display.grid import Grid
+from is_matrix_forge.led_matrix.display.helpers import render_matrix
+
+
+def test_render_matrix_handles_small_grid(monkeypatch):
+    """Rendering a grid smaller than 9×34 should not error."""
+    captured = {}
+
+    def fake_send_command(dev, cmd, vals):
+        captured['vals'] = vals
+
+    monkeypatch.setattr(
+        'is_matrix_forge.led_matrix.display.helpers.send_command',
+        fake_send_command,
+    )
+
+    glyph = [
+        0, 0, 0, 0, 0,
+        1, 1, 0, 1, 1,
+        1, 1, 1, 1, 1,
+        0, 1, 1, 1, 0,
+        0, 0, 1, 0, 0,
+        0, 0, 0, 0, 0,
+    ]
+    grid = Grid(init_grid=glyph)
+
+    class DummyDevice:
+        def draw_grid(self, grid_obj):
+            render_matrix(self, grid_obj.grid if isinstance(grid_obj, Grid) else grid_obj)
+
+    device = DummyDevice()
+    grid.draw(device)
+
+    assert len(captured['vals']) == 39


### PR DESCRIPTION
## Summary
- support initializing Grid from flat 5x6 symbol lists
- fall back gracefully when optional cv2 is missing
- simplify led_matrix package init to avoid heavy side effects

## Testing
- `PYTHONPATH=$PWD pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a2b0a2daf8832d81e07b75d1a6e0d2

## Summary by Sourcery

Allow grid display code to accept flat glyph lists and streamline the LED matrix package initializer to avoid import-time side effects.

New Features:
- Allow Grid to be initialized from a flat 5×6 glyph list by inferring its dimensions and converting it to the internal column-major format.

Bug Fixes:
- Correct expected values in existing grid pixel shifting tests.

Enhancements:
- Wrap hardware-dependent imports in the package initializer to remove import-time side effects and enable usage without optional dependencies.
- Provide a graceful fallback for get_controllers when those dependencies are absent.

Tests:
- Add a test for flat glyph list initialization in Grid.
- Update device shift tests to match corrected behavior.