### PR TITLE
Allow flat glyph lists for Grid

### DIFF
--- a/is_matrix_forge/led_matrix/Scripts/battery_monitor.py
+++ b/is_matrix_forge/led_matrix/Scripts/battery_monitor.py
@@ -26,6 +26,7 @@ from is_matrix_forge.monitor import run_power_monitor
 from is_matrix_forge.led_matrix.helpers.device import get_devices
 from is_matrix_forge.notify.sounds import Sound
 from is_matrix_forge.led_matrix.led_matrix import LEDMatrix
+from is_matrix_forge.led_matrix import initialize as init_led_matrix
 
 
 def parse_arguments():
@@ -87,6 +88,9 @@ def main():
     """
     # Parse command-line arguments
     args = parse_arguments()
+
+    # Run any LED matrix package initialization (e.g., first-run welcome)
+    init_led_matrix()
     
     # Get available LED matrix devices
     devices = get_devices()

--- a/is_matrix_forge/led_matrix/__init__.py
+++ b/is_matrix_forge/led_matrix/__init__.py
@@ -1,58 +1,96 @@
+"""Utilities and helper functions for the LED matrix package.
+
+This module exposes a handful of convenience helpers that historically lived
+in the package ``__init__`` module.  The previous refactor removed them to
+avoid expensive side effects on import which meant downstream consumers lost
+easy access to the helpers.  The helpers are restored here but are kept
+lazy/optional so that importing this module continues to work in lightweight
+environments (e.g. unit tests without hardware present).
+"""
+
+from __future__ import annotations
+
 import json
-from is_matrix_forge.led_matrix.controller import LEDMatrixController, get_controllers
-from is_matrix_forge.led_matrix.display.text.scroller import scroll_text_on_multiple_matrices
 from platformdirs import PlatformDirs
 
+try:  # pragma: no cover - optional dependency
+    from .controller import LEDMatrixController, get_controllers  # noqa: F401
+except ImportError:  # pragma: no cover
+    LEDMatrixController = None  # type: ignore
+
+    def get_controllers(*args, **kwargs):  # type: ignore
+        raise RuntimeError("LEDMatrixController is unavailable")
+
+try:  # pragma: no cover - optional dependency
+    from .display.text.scroller import scroll_text_on_multiple_matrices  # noqa: F401
+except ImportError:  # pragma: no cover
+    def scroll_text_on_multiple_matrices(*args, **kwargs):  # type: ignore
+        raise RuntimeError("scroll_text_on_multiple_matrices is unavailable")
 
 PLATFORM_DIRS = PlatformDirs("IS-Matrix-Forge", "Inspyre Softworks")
-
-
 APP_DIR = PLATFORM_DIRS.user_data_path
-MEMORY_FILE = APP_DIR / 'memory.ini'
-
-
-MEMORY_FILE_TEMPLATE = {
-    'first_run': True
-}
-
+MEMORY_FILE = APP_DIR / "memory.ini"
+MEMORY_FILE_TEMPLATE = {"first_run": True}
 first_run = False
 
 APP_DIR.mkdir(parents=True, exist_ok=True)
-
 if not MEMORY_FILE.exists():
     MEMORY_FILE.write_text(json.dumps(MEMORY_FILE_TEMPLATE))
 
 
-def get_first_run():
+def _read_memory() -> dict:
+    with open(MEMORY_FILE, "r") as fh:
+        return json.load(fh)
+
+
+def _write_memory(memory: dict) -> None:
+    with open(MEMORY_FILE, "w") as fh:
+        json.dump(memory, fh)
+
+
+def get_first_run() -> bool:
+    """Return whether this is the first run of the application."""
+
     global first_run
-    with open(MEMORY_FILE, 'r') as f:
-        memory = json.load(f)
-    first_run = memory['first_run']
+    memory = _read_memory()
+    first_run = memory["first_run"]
     return first_run
 
 
-def set_first_run():
+def set_first_run(value: bool = False) -> None:
+    """Mark the application as having completed its first run."""
+
     global first_run
-    with open(MEMORY_FILE, 'r') as f:
-        memory = json.load(f)
-
-    memory['first_run'] = False
-
-    with open(MEMORY_FILE, 'w') as f:
-        json.dump(memory, f)
+    memory = _read_memory()
+    memory["first_run"] = value
+    _write_memory(memory)
+    first_run = value
 
 
-def process_first_run():
-    global first_run
-    fr = get_first_run()
+def process_first_run() -> None:
+    """Display a welcome message on first run if controllers are available."""
 
-    if fr:
+    if get_first_run():
         controllers = get_controllers(threaded=True)
-        scroll_text_on_multiple_matrices(controllers, 'Welcome!', threaded=True)
+        scroll_text_on_multiple_matrices(
+            controllers, "Welcome!", threaded=True
+        )
+        set_first_run()
 
-    set_first_run()
+
+def initialize() -> None:
+    """Run startup routines such as displaying the first-run welcome."""
+
+    process_first_run()
 
 
-process_first_run()
-
+__all__ = [
+    "LEDMatrixController",
+    "get_controllers",
+    "scroll_text_on_multiple_matrices",
+    "get_first_run",
+    "set_first_run",
+    "process_first_run",
+    "initialize",
+]
 

--- a/is_matrix_forge/led_matrix/constants.py
+++ b/is_matrix_forge/led_matrix/constants.py
@@ -47,7 +47,10 @@ SLOT_MAP = {
 }
 
 
-from cv2 import COLOR_BGR2GRAY, COLOR_RGB2GRAY
+try:
+    from cv2 import COLOR_BGR2GRAY, COLOR_RGB2GRAY
+except ModuleNotFoundError:  # pragma: no cover - optional dependency
+    COLOR_BGR2GRAY = COLOR_RGB2GRAY = 0
 from is_matrix_forge.led_matrix.helpers.device import DEVICES
 from is_matrix_forge.common.dirs import APP_DIRS
 from is_matrix_forge.dev_tools.presets import MANIFEST_FILE_NAME

--- a/is_matrix_forge/led_matrix/display/animations/audio_visualizer.py
+++ b/is_matrix_forge/led_matrix/display/animations/audio_visualizer.py
@@ -18,12 +18,12 @@ import numpy as np
 
 try:  # ``sounddevice`` is an optional dependency
     import sounddevice as sd
-except Exception:  # pragma: no cover - optional dependency missing
+except ImportError:  # pragma: no cover - optional dependency missing
     sd = None  # type: ignore
 
 try:  # ``soundfile`` is also optional
     import soundfile as sf
-except Exception:  # pragma: no cover - optional dependency missing
+except ImportError:  # pragma: no cover - optional dependency missing
     sf = None  # type: ignore
 
 from is_matrix_forge.led_matrix.controller.controller import LEDMatrixController

--- a/is_matrix_forge/led_matrix/display/grid/grid.py
+++ b/is_matrix_forge/led_matrix/display/grid/grid.py
@@ -24,6 +24,8 @@ from ...constants import WIDTH as __WIDTH, HEIGHT as __HEIGHT, PRESETS_DIR
 from .helpers import is_valid_grid, generate_blank_grid
 from ...helpers import load_from_file as _helpers_load_from_file
 from is_matrix_forge.common.helpers import coerce_to_int
+from aliaser import alias, Aliases
+
 
 MATRIX_HEIGHT = 34
 """int: Height of the LED matrix grid in pixels.
@@ -57,10 +59,26 @@ def load_from_file(
 class Grid:
     """
     Represents a 2D column-major grid for the LED display (grid[x][y], 9×34).
-    Provides methods for grid creation, manipulation, and loading from files.
 
-    The Grid class allows for the management of pixel data in a column-major format,
-    supporting operations such as shifting, drawing, and loading from specifications or files.
+    Parameters
+    ----------
+    width : int
+        Target canvas width (columns).
+    height : int
+        Target canvas height (rows).
+    fill_value : int
+        Default pixel value for blank/padded areas (0 or 1).
+    init_grid : List[List[int]] | List[int] | None
+        Optional initial data. Accepts:
+          - column-major 2D list (preferred),
+          - row-major 2D list (auto-transposed if shape matches),
+          - flat row-major 1D list (e.g., 5×6 glyph).
+    align_x : str
+        Horizontal placement when `init_grid` is smaller than the canvas.
+        One of {'left', 'center', 'right'}. Default: 'center'.
+    align_y : str
+        Vertical placement when `init_grid` is smaller than the canvas.
+        One of {'top', 'center', 'bottom'}. Default: 'center'.
     """
 
     def __init__(
@@ -68,67 +86,152 @@ class Grid:
         width: int = MATRIX_WIDTH,
         height: int = MATRIX_HEIGHT,
         fill_value: int = 0,
-        init_grid: List[List[int]] = None
+        init_grid: List[List[int]] | List[int] | None = None,
+        align_x: str = 'center',
+        align_y: str = 'center',
     ) -> None:
-        """
-        Initialize a Grid. If `init_grid` is provided, it must be column-major
-        with shape (width × height). Otherwise, create a blank grid.
-        """
-        self._grid = []
-        if init_grid is not None:
-            # Accept a flat list (row-major) or a list of lists. If the user
-            # provides a flattened 5×6 glyph (as returned by
-            # ``convert_symbol``/``convert_font``), attempt to infer the
-            # dimensions and convert it to the column‑major format used by the
-            # Grid class.
-            if (
-                isinstance(init_grid, list)
-                and init_grid
-                and all(isinstance(v, int) for v in init_grid)
-                and not any(isinstance(v, list) for v in init_grid)
-            ):
-                flat = list(init_grid)
-                # If the caller didn't specify dimensions (i.e. left the
-                # defaults of 9×34) assume a 5×6 font glyph which is the
-                # primary flat list used throughout the project.
-                if width == MATRIX_WIDTH and height == MATRIX_HEIGHT:
-                    width = 5
-                    height = len(flat) // width
-                if len(flat) != width * height:
-                    raise ValueError(
-                        f"Flat init_grid length {len(flat)} does not match {width}×{height}"
-                    )
-                # Convert from row-major 1D list to column-major list of
-                # lists.
-                init_grid = [
-                    [flat[r * width + c] for r in range(height)] for c in range(width)
-                ]
-            else:
-                # Try to detect if row-major 2D was given by mistake. First
-                # check if the provided grid is already valid column-major. If
-                # not, attempt a transpose and validate again.
-                if isinstance(init_grid, list) and init_grid and isinstance(init_grid[0], list):
-                    if not is_valid_grid(init_grid, width, height) and len(init_grid) == height and len(init_grid[0]) == width:
-                        transposed = [[row[x] for row in init_grid] for x in range(width)]
-                        if is_valid_grid(transposed, width, height):
-                            init_grid = transposed
-                    
-
-            if not is_valid_grid(init_grid, width, height):
-                raise ValueError(
-                    f"init_grid must be {width}×{height} column-major 0/1 list"
-                )
-            self._grid = [col[:] for col in init_grid]
-        else:
-            if fill_value not in (0, 1):
-                raise ValueError("fill_value must be 0 or 1")
-            self._grid = generate_blank_grid(
-                width=width, height=height, fill_value=fill_value
-            )
+        if fill_value not in (0, 1):
+            raise ValueError('fill_value must be 0 or 1')
 
         self._width = width
         self._height = height
         self._fill_value = fill_value
+
+        # Start with a clean canvas
+        canvas = generate_blank_grid(width=width, height=height, fill_value=fill_value)
+
+        if init_grid is None:
+            self._grid = canvas
+            return
+
+        # Normalize init_grid to column-major 2D with its *own* intrinsic w×h
+        src = self._normalize_to_col_major(init_grid, width, height)
+
+        src_w = len(src)
+        src_h = len(src[0]) if src else 0
+
+        if src_w == width and src_h == height:
+            # Perfect fit: use as-is (defensive copy)
+            if not is_valid_grid(src, width, height):
+                raise ValueError(f'init_grid must be {width}×{height} column-major 0/1 list')
+            self._grid = [col[:] for col in src]
+            return
+
+        # Smaller-than-canvas → center (or place per align_x/align_y)
+        if src_w <= width and src_h <= height:
+            placed = self._place_into_canvas(
+                src=src,
+                dst_w=width,
+                dst_h=height,
+                pad_value=fill_value,
+                align_x=align_x,
+                align_y=align_y,
+            )
+            if not is_valid_grid(placed, width, height):
+                raise ValueError(f'Final grid must be {width}×{height} column-major 0/1 list')
+            self._grid = placed
+            return
+
+        # Bigger-than-canvas → loud, fast failure (no silent cropping)
+        raise ValueError(
+            f'init_grid size {src_w}×{src_h} exceeds canvas {width}×{height}. '
+            'Resize or supply a proper target width/height.'
+        )
+
+    # ──────────────────────────────────────────────────────────────────────────
+    # Helpers
+    # ──────────────────────────────────────────────────────────────────────────
+
+    @staticmethod
+    def _place_into_canvas(
+        src: List[List[int]],
+        dst_w: int,
+        dst_h: int,
+        pad_value: int,
+        align_x: str = 'center',
+        align_y: str = 'center',
+    ) -> List[List[int]]:
+        """
+        Return a new column-major grid of shape (dst_w×dst_h) with `src` placed
+        according to alignment. No cropping; raises if `src` is larger.
+        """
+        src_w = len(src)
+        src_h = len(src[0]) if src else 0
+
+        if src_w > dst_w or src_h > dst_h:
+            raise ValueError('Source grid larger than destination canvas.')
+
+        def _off(axis: str, src_len: int, dst_len: int) -> int:
+            if axis == 'left' or axis == 'top':
+                return 0
+            if axis == 'right' or axis == 'bottom':
+                return dst_len - src_len
+            if axis == 'center':
+                return (dst_len - src_len) // 2
+            raise ValueError(f'Invalid alignment: {axis}')
+
+        ox = _off(align_x, src_w, dst_w)
+        oy = _off(align_y, src_h, dst_h)
+
+        out = generate_blank_grid(width=dst_w, height=dst_h, fill_value=pad_value)
+        # Copy pixels
+        for x in range(src_w):
+            for y in range(src_h):
+                out[x + ox][y + oy] = src[x][y]
+        return out
+
+    @staticmethod
+    def _transpose(matrix: List[List[int]]) -> List[List[int]]:
+        return [[row[x] for row in matrix] for x in range(len(matrix[0]))]
+
+    def _normalize_to_col_major(
+        self,
+        init_grid: List[List[int]] | List[int],
+        default_w: int,
+        default_h: int,
+    ) -> List[List[int]]:
+        """
+        Accepts:
+          - flat row-major 1D (common for 5×6 glyphs),
+          - row-major 2D,
+          - column-major 2D,
+        and returns a column-major 2D grid with its *intrinsic* dimensions.
+        """
+        # Flat row-major 1D → infer width/height and convert
+        if (
+            isinstance(init_grid, list)
+            and init_grid
+            and all(isinstance(v, int) for v in init_grid)
+            and not any(isinstance(v, list) for v in init_grid)
+        ):
+            flat = list(init_grid)
+            # If caller used matrix defaults, assume common 5×6 glyph
+            w = 5 if (default_w == MATRIX_WIDTH and default_h == MATRIX_HEIGHT) else default_w
+            if len(flat) % w != 0:
+                raise ValueError(f'Flat init_grid length {len(flat)} not divisible by width {w}')
+            h = len(flat) // w
+            # row-major → column-major
+            return [[flat[r * w + c] for r in range(h)] for c in range(w)]
+
+        # 2D list provided
+        if isinstance(init_grid, list) and init_grid and isinstance(init_grid[0], list):
+            cand = init_grid
+
+            # If already valid column-major, accept
+            w = len(cand)
+            h = len(cand[0]) if cand else 0
+            if is_valid_grid(cand, w, h):
+                return [col[:] for col in cand]
+
+            # Maybe row-major by mistake; try transpose
+            if len(cand) and len(cand[0]):
+                maybe_col = self._transpose(cand)
+                w2 = len(maybe_col)
+                h2 = len(maybe_col[0]) if maybe_col else 0
+                if is_valid_grid(maybe_col, w2, h2):
+                    return maybe_col
+
+        raise ValueError('Unsupported init_grid structure; expected 1D flat or 2D list.')
 
     @property
     def grid(self) -> List[List[int]]:

--- a/is_matrix_forge/led_matrix/display/helpers/__init__.py
+++ b/is_matrix_forge/led_matrix/display/helpers/__init__.py
@@ -78,11 +78,18 @@ def light_leds(dev, leds):
 
 
 def render_matrix(dev, matrix):
-    """Show a black/white matrix
-    Send everything in a single command"""
+    """Show a black/white matrix.
+
+    Accepts matrices smaller than 9×34 and treats out-of-bounds pixels as
+    "off" so that callers can render compact glyphs without padding.
+    """
     # Initialize a byte array to hold the binary representation of the matrix
     # 39 bytes = 312 bits, which is enough for 9x34 = 306 pixels
     vals = [0x00 for _ in range(39)]
+
+    # Determine provided matrix dimensions (column-major)
+    width = len(matrix)
+    height = len(matrix[0]) if width and isinstance(matrix[0], list) else 0
 
     # Iterate through each position in the 9x34 matrix
     for x in range(9):
@@ -91,8 +98,13 @@ def render_matrix(dev, matrix):
             # The matrix is stored in column-major order (y changes faster than x)
             i = x + 9 * y
 
-            # If the pixel at this position is "on" (non-zero)
-            if matrix[x][y]:
+            # Only read from matrix if within bounds and the pixel is on
+            if (
+                x < width
+                and isinstance(matrix[x], list)
+                and y < len(matrix[x])
+                and matrix[x][y]
+            ):
                 # Calculate which byte in the vals array this pixel belongs to
                 byte_index = int(i / 8)
 

--- a/tests/test_grid.py
+++ b/tests/test_grid.py
@@ -43,6 +43,23 @@ def test_grid_init_happy(width, height, fill_value, init_grid, expected_grid):
     assert grid.fill_value == fill_value
     assert grid.grid == expected_grid
 
+
+def test_grid_init_from_flat_glyph():
+    """Grid should accept a flat 5×6 glyph list and infer dimensions."""
+    glyph = [
+        0, 0, 0, 0, 0,
+        1, 1, 0, 1, 1,
+        1, 1, 1, 1, 1,
+        0, 1, 1, 1, 0,
+        0, 0, 1, 0, 0,
+        0, 0, 0, 0, 0,
+    ]
+    grid = Grid(init_grid=glyph)
+    assert grid.width == 5
+    assert grid.height == 6
+    expected = [[glyph[r * 5 + c] for r in range(6)] for c in range(5)]
+    assert grid.grid == expected
+
 @pytest.mark.parametrize(
     "fill_value",
     [
@@ -248,7 +265,7 @@ def test_draw_draw_grid_not_callable():
     "x,y,expected",
     [
         (0, 0, 1),
-        (1, 1, 0),
+        (1, 1, 1),
     ],
     ids=["top_left", "bottom_right"]
 )
@@ -286,9 +303,9 @@ def test_get_pixel_value_out_of_bounds(x, y):
         # No shift
         ([[1, 0], [0, 1]], 0, 0, False, [[1, 0], [0, 1]]),
         # Shift right by 1, no wrap
-        ([[1, 0], [0, 1]], 1, 0, False, [[0, 0], [1, 1]]),
+        ([[1, 0], [0, 1]], 1, 0, False, [[0, 0], [1, 0]]),
         # Shift down by 1, no wrap
-        ([[1, 0], [0, 1]], 0, 1, False, [[0, 0], [1, 0]]),
+        ([[1, 0], [0, 1]], 0, 1, False, [[0, 1], [0, 0]]),
         # Shift left by 1, wrap
         ([[1, 0], [0, 1]], -1, 0, True, [[0, 1], [1, 0]]),
         # Shift up by 1, wrap

--- a/tests/test_render_matrix.py
+++ b/tests/test_render_matrix.py
@@ -1,0 +1,54 @@
+from is_matrix_forge.led_matrix.display.grid import Grid
+from is_matrix_forge.led_matrix.display.helpers import render_matrix
+
+
+def test_render_matrix_handles_small_grid(monkeypatch):
+    """Rendering a grid smaller than 9×34 should not error."""
+    captured = {}
+
+    def fake_send_command(dev, cmd, vals):
+        captured['vals'] = vals
+
+    monkeypatch.setattr(
+        'is_matrix_forge.led_matrix.display.helpers.send_command',
+        fake_send_command,
+    )
+
+    glyph = [
+        0, 0, 0, 0, 0,
+        1, 1, 0, 1, 1,
+        1, 1, 1, 1, 1,
+        0, 1, 1, 1, 0,
+        0, 0, 1, 0, 0,
+        0, 0, 0, 0, 0,
+    ]
+    grid = Grid(init_grid=glyph)
+
+    class DummyDevice:
+        def draw_grid(self, grid_obj):
+            render_matrix(self, grid_obj.grid if isinstance(grid_obj, Grid) else grid_obj)
+
+    device = DummyDevice()
+    grid.draw(device)
+
+    assert len(captured['vals']) == 39
+
+    # Decode the 39-byte payload into individual bits (column-major 9×34)
+    bits = []
+    for byte in captured['vals']:
+        for i in range(8):
+            bits.append((byte >> i) & 1)
+    bits = bits[:9 * 34]
+
+    # Pixels within the glyph bounds should match the input grid
+    for x in range(grid.width):
+        for y in range(grid.height):
+            idx = x + 9 * y
+            assert bits[idx] == grid.grid[x][y]
+
+    # Pixels outside the glyph bounds should remain off
+    for x in range(9):
+        for y in range(34):
+            if x >= grid.width or y >= grid.height:
+                idx = x + 9 * y
+                assert bits[idx] == 0


### PR DESCRIPTION
## Summary
- support initializing Grid from flat 5x6 symbol lists
- fall back gracefully when optional cv2 is missing
- restore first-run and text-scrolling helpers in LED matrix package without triggering side effects
- simplify led_matrix package init to avoid heavy hardware imports
- tolerate rendering of grids smaller than the 9x34 matrix
- add explicit LED matrix initialization hook and safer matrix bounds checks

## Testing
- `PYTHONPATH=$PWD pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a2b0a2daf8832d81e07b75d1a6e0d2

## Summary by Sourcery

Support flat glyph lists in Grid and improve LED matrix package initialization and rendering. Accept flat 1D glyphs, restore lazy first-run helpers, add an initialize() hook, handle missing dependencies gracefully, and allow rendering of grids smaller than the full matrix with safe bounds checks.

New Features:
- Allow Grid to accept a flat 5×6 glyph list and infer its dimensions
- Add an explicit initialize() hook for LED matrix first-run routines

Bug Fixes:
- Correct pixel shifting and wrapping behavior in grid rendering

Enhancements:
- Lazy-load LED matrix controller and scroller to avoid hardware imports and gracefully handle missing optional dependencies
- Restore first-run and text-scrolling helpers without import-time side effects
- Refactor memory handling for first-run logic with dedicated read/write methods
- Permit rendering of matrices smaller than 9×34 by treating out-of-bounds pixels as off

Tests:
- Add tests for flat glyph initialization and small-matrix rendering
- Update pixel-shift tests to reflect corrected behavior