### PR TITLE
ci: publish prereleases to TestPyPI

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -19,11 +19,25 @@ jobs:
       - uses: abatilo/actions-poetry@v3
       - run: poetry install --no-interaction --no-root
       - run: poetry build
-      - uses: pypa/gh-action-pypi-publish@release/v1
+      - name: Determine release target
+        id: vars
+        run: |
+          VERSION=$(poetry version -s)
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          if [[ "$VERSION" == *"a"* || "$VERSION" == *"b"* || "$VERSION" == *"rc"* || "$VERSION" == *"dev"* ]]; then
+            echo "prerelease=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "prerelease=false" >> "$GITHUB_OUTPUT"
+          fi
+      - name: Publish to PyPI
+        if: steps.vars.outputs.prerelease == 'false'
+        uses: pypa/gh-action-pypi-publish@release/v1
         with:
           user: __token__
           password: ${{ secrets.PYPI_TOKEN }}
-      - uses: pypa/gh-action-pypi-publish@release/v1
+      - name: Publish to Test PyPI
+        if: steps.vars.outputs.prerelease == 'true'
+        uses: pypa/gh-action-pypi-publish@release/v1
         with:
           repository-url: https://test.pypi.org/legacy/
           user: __token__

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,11 +1,12 @@
 name: Build and Publish
 
 on:
-  release:
-    types: [created]
+  push:
+    tags:
+      - 'v*'
 
 permissions:
-  contents: read
+  contents: write
   id-token: write
 
 jobs:
@@ -42,3 +43,10 @@ jobs:
           repository-url: https://test.pypi.org/legacy/
           user: __token__
           password: ${{ secrets.TEST_PYPI_TOKEN }}
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v1
+        with:
+          tag_name: ${{ github.ref_name }}
+          name: v${{ steps.vars.outputs.version }}
+          generate_release_notes: true
+          prerelease: ${{ steps.vars.outputs.prerelease }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -17,34 +17,33 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: '3.12'
-      - uses: abatilo/actions-poetry@v3
+      - uses: abatilo/actions-poetry@fd0e6716a0de25ef6ade151b8b53190b0376acfd # v3
       - run: poetry install --no-interaction --no-root
+      - run: poetry run pytest
       - run: poetry build
       - name: Determine release target
         id: vars
         run: |
           VERSION=$(poetry version -s)
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
-          if [[ "$VERSION" == *"a"* || "$VERSION" == *"b"* || "$VERSION" == *"rc"* || "$VERSION" == *"dev"* ]]; then
-            echo "prerelease=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "prerelease=false" >> "$GITHUB_OUTPUT"
-          fi
-      - name: Publish to PyPI
-        if: steps.vars.outputs.prerelease == 'false'
-        uses: pypa/gh-action-pypi-publish@release/v1
+          env VERSION=$VERSION python - <<'PY'
+from packaging.version import Version
+import os
+version = os.environ["VERSION"]
+pr = Version(version).is_prerelease
+with open(os.environ["GITHUB_OUTPUT"], "a") as fh:
+    fh.write(f"prerelease={str(pr).lower()}\n")
+    url = "https://test.pypi.org/legacy/" if pr else "https://upload.pypi.org/legacy/"
+    fh.write(f"repository_url={url}\n")
+PY
+      - name: Publish package
+        uses: pypa/gh-action-pypi-publish@76f52bc884231f62b9a034ebfe128415bbaabdfc # release/v1
         with:
           user: __token__
-          password: ${{ secrets.PYPI_TOKEN }}
-      - name: Publish to Test PyPI
-        if: steps.vars.outputs.prerelease == 'true'
-        uses: pypa/gh-action-pypi-publish@release/v1
-        with:
-          repository-url: https://test.pypi.org/legacy/
-          user: __token__
-          password: ${{ secrets.TEST_PYPI_TOKEN }}
+          password: ${{ steps.vars.outputs.prerelease == 'true' && secrets.TEST_PYPI_TOKEN || secrets.PYPI_TOKEN }}
+          repository-url: ${{ steps.vars.outputs.repository_url }}
       - name: Create GitHub Release
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@26994186c0ac3ef5cae75ac16aa32e8153525f77 # v1
         with:
           tag_name: ${{ github.ref_name }}
           name: v${{ steps.vars.outputs.version }}


### PR DESCRIPTION
## Summary
- publish pre-releases to Test PyPI and stable releases to PyPI

## Testing
- `python3 -m pytest -q` *(fails: tests/test_controller_mro.py::test_controller_init_order, tests/test_grid.py::test_grid_init_from_flat_glyph, tests/test_grid.py::test_grid_init_invalid_init_grid)*

------
https://chatgpt.com/codex/tasks/task_e_68af9e4624d0832d9a9ccc4ca745798c

## Summary by Sourcery

Update the GitHub Actions publishing workflow to run tests, handle prerelease detection, and route artifacts to TestPyPI for prereleases and PyPI for stable releases.

Enhancements:
- Pin the abatilo/actions-poetry action to a specific commit for consistency
- Add a pytest run step before building the package

CI:
- Change workflow trigger to tag pushes matching v*
- Grant contents write permission and update action versions
- Introduce a step to detect prerelease versions and set repository URL and token dynamically
- Publish packages to TestPyPI for prereleases and to PyPI for stable releases
- Create GitHub Release with autogenerated notes and prerelease flag based on version