### PR TITLE
1.0.0 dev.19: address review feedback

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -53,7 +53,7 @@ jobs:
       # Build a nice changelog from PRs/commits between tags
       - name: Generate changelog
         id: changelog
-        uses: mikepenz/release-changelog-builder-action@v5
+        uses: mikepenz/release-changelog-builder-action@c9dc8369bccbc41e0ac887f8fd674f5925d315f7 # v5
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:

--- a/is_matrix_forge/led_matrix/Scripts/install_presets/main.py
+++ b/is_matrix_forge/led_matrix/Scripts/install_presets/main.py
@@ -46,6 +46,8 @@ from typing import List, Dict, Optional, Union
 from pathlib import Path
 import requests
 import hashlib
+from requests.adapters import HTTPAdapter
+from urllib3.util.retry import Retry
 from is_matrix_forge.progress import tqdm
 
 from is_matrix_forge.led_matrix.constants import PROJECT_URLS, APP_DIRS, GITHUB_REQ_HEADERS as REQ_HEADERS
@@ -87,6 +89,10 @@ class PresetInstaller(Loggable):
         # HTTP session for connection reuse
         self.session = requests.Session()
         self.session.headers.update(self.headers)
+        retry = Retry(total=3, backoff_factor=0.5, status_forcelist=[500, 502, 503, 504])
+        adapter = HTTPAdapter(max_retries=retry)
+        self.session.mount('http://', adapter)
+        self.session.mount('https://', adapter)
 
     def run(self):
         log = self.method_logger

--- a/is_matrix_forge/led_matrix/controller/components/brightness/helpers/levels.py
+++ b/is_matrix_forge/led_matrix/controller/components/brightness/helpers/levels.py
@@ -7,7 +7,7 @@ class Levels:
     def iter(spec: FadeSpec, *, easing: Callable[[float], float]) -> Iterator[int]:
         delta = spec.target - spec.start
         total = spec.total_steps
-        for k in range(1, total + 1):
-            progress = easing(k / total)
+        for k in range(total + 1):
+            progress = easing(k / total) if total else 1.0
             level = spec.start + int(round(progress * delta))
             yield max(0, min(100, level))

--- a/is_matrix_forge/led_matrix/controller/components/brightness/helpers/percent.py
+++ b/is_matrix_forge/led_matrix/controller/components/brightness/helpers/percent.py
@@ -4,7 +4,10 @@ class Percent:
     @staticmethod
     def norm(val: int | float | str) -> int:
         if isinstance(val, str):
-            val = float(val.strip('%'))
+            s = val.strip()
+            if s.endswith('%'):
+                s = s[:-1].strip()
+            val = float(s)
         pct = int(round(float(val)))
         if not (0 <= pct <= 100):
             raise ValueError('Percentage must be between 0 and 100')
@@ -12,14 +15,14 @@ class Percent:
 
     @staticmethod
     def resolve(target: int | float | str, *, current: int) -> int:
-        if isinstance(target, str):
-            s = target.strip()
-            if s.startswith(('+', '-')):
-                sign = 1 if s[0] == '+' else -1
-                num = s[1:].strip()
-                if num.endswith('%'):
-                    num = num[:-1].strip()
-                delta = float(num)
-                return max(0, min(100, int(round(current + sign * delta))))
-            return Percent.norm(s)
-        return Percent.norm(target)
+        if not isinstance(target, str):
+            return Percent.norm(target)
+        s = target.strip()
+        if s.startswith(('+', '-')):
+            sign = 1 if s[0] == '+' else -1
+            num = s[1:].strip()
+            if num.endswith('%'):
+                num = num[:-1].strip()
+            delta = float(num)
+            return max(0, min(100, int(round(current + sign * delta))))
+        return Percent.norm(s)

--- a/is_matrix_forge/led_matrix/controller/components/brightness/helpers/safe_ops.py
+++ b/is_matrix_forge/led_matrix/controller/components/brightness/helpers/safe_ops.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 from threading import Thread
+import logging
+
 
 class SafeOps:
     @staticmethod
@@ -7,28 +9,28 @@ class SafeOps:
         if callable(fn):
             try:
                 fn()
-            except Exception:
-                pass
+            except Exception as e:
+                logging.debug(f"Exception in call: {e}", exc_info=True)
 
     @staticmethod
     def setattr(obj, name: str, value) -> None:
         try:
             setattr(obj, name, value)
-        except Exception:
-            pass
+        except Exception as e:
+            logging.debug(f"Exception in setattr: {e}", exc_info=True)
 
     @staticmethod
     def join(thread: Thread, *, timeout: float) -> None:
         try:
             if thread.is_alive():
                 thread.join(timeout=timeout)
-        except Exception:
-            pass
+        except Exception as e:
+            logging.debug(f"Exception in join: {e}", exc_info=True)
 
     @staticmethod
     def clear(device_obj) -> None:
         if hasattr(device_obj, 'clear'):
             try:
                 device_obj.clear()
-            except Exception:
-                pass
+            except Exception as e:
+                logging.debug(f"Exception in clear: {e}", exc_info=True)

--- a/is_matrix_forge/led_matrix/controller/components/brightness/manager.py
+++ b/is_matrix_forge/led_matrix/controller/components/brightness/manager.py
@@ -139,7 +139,7 @@ class BrightnessManager:
             else self.FACTORY_DEFAULT_BRIGHTNESS
         )
         self._brightness: Optional[int] = None
-        self._set_brightness_on_init = not bool(skip_init_brightness_set)
+        self._set_brightness_on_init = not skip_init_brightness_set
 
         # Optional user-settable easing – default to linear if not provided
         # You can override self.easing at runtime with any f:[0,1]->[0,1].
@@ -305,8 +305,11 @@ class BrightnessManager:
         """
         pct = Percent.norm(brightness)
         raw = percentage_to_value(max_value=255, percent=pct)
+        device = getattr(self, 'device', None)
+        if device is None:
+            raise RuntimeError("BrightnessManager requires a 'device' attribute for hardware calls")
         try:
-            _set_brightness_raw(self.device, raw)
+            _set_brightness_raw(device, raw)
         except ValueError as e:
             raise InvalidBrightnessError(raw) from e
         self._brightness = pct
@@ -326,7 +329,7 @@ class BrightnessManager:
         # Zero-duration fast path
         if duration <= 0:
             self.set_brightness(Percent.norm(target))
-            if clear_when_done and int(target) == 0:
+            if clear_when_done and target == 0:
                 SafeOps.clear(self)
             return None
 

--- a/is_matrix_forge/scripts/preset_installer.py
+++ b/is_matrix_forge/scripts/preset_installer.py
@@ -7,10 +7,17 @@ This module now delegates to the canonical entry point at:
 Kept to avoid breaking existing imports or module paths.
 """
 
+import warnings
 from is_matrix_forge.led_matrix.Scripts.install_presets.main import main as _main
 
 
 def main():  # pragma: no cover - thin wrapper
+    warnings.warn(
+        "is_matrix_forge.scripts.preset_installer is deprecated; use "
+        "is_matrix_forge.led_matrix.Scripts.install_presets.main instead",
+        DeprecationWarning,
+        stacklevel=2,
+    )
     _main()
 
 


### PR DESCRIPTION
## Summary
- handle whitespace and relative strings in `Percent` helpers
- include initial brightness in fade level iteration
- validate device presence and log safe op exceptions
- add retries to preset installer HTTP session and deprecate legacy wrapper
- pin changelog action to commit SHA

## Testing
- `PYTHONPATH=. pytest` *(fails: ModuleNotFoundError: No module named 'aliaser')*

------
https://chatgpt.com/codex/tasks/task_e_68b23e84f338832d81a70478a726e7a2

## Summary by Sourcery

Improve brightness helpers with robust parsing, logging, and validation; enhance fade iteration; deprecate legacy preset installer with HTTP retries; and pin changelog action in CI

Bug Fixes:
- Validate presence of device attribute in BrightnessManager and raise if missing
- Fix clear_when_done logic to only clear on exact zero target

Enhancements:
- Make Percent helper parse whitespace and trailing '%' consistently and streamline resolve logic
- Log exceptions in SafeOps methods instead of silently ignoring them
- Include initial brightness step and handle zero steps in fade level iterator
- Deprecate legacy preset installer wrapper with a warning
- Add retry strategy to HTTP session in preset installer

CI:
- Pin release-changelog-builder-action to a specific commit SHA