### PR TITLE
Fix animation frame playback device handling

### DIFF
--- a/is_matrix_forge/led_matrix/Scripts/led_matrix/__init__.py
+++ b/is_matrix_forge/led_matrix/Scripts/led_matrix/__init__.py
@@ -1,5 +1,7 @@
 from is_matrix_forge.led_matrix.Scripts.led_matrix.arguments import Arguments
 from is_matrix_forge import get_controllers
+from .arguments.commands.scroll_text import DIRECTION_MAP
+
 
 ARGUMENTS = Arguments()
 
@@ -16,7 +18,7 @@ def scroll_text_command(cli_args=ARGUMENTS):
     matrix = CONTROLLERS[0]
     print(cli_args.input)
 
-    matrix.scroll_text(cli_args.input)
+    matrix.scroll_text(cli_args.input, direction=DIRECTION_MAP[cli_args.direction.strip().lower()])
 
 
 def main(cli_args=ARGUMENTS):

--- a/is_matrix_forge/led_matrix/Scripts/led_matrix/arguments/__init__.py
+++ b/is_matrix_forge/led_matrix/Scripts/led_matrix/arguments/__init__.py
@@ -40,17 +40,8 @@ class Arguments(ArgumentParser):
         return self.__scroll_parser
 
     def __build_scroll_text(self):
-        if not self.building or self.built:
-            return
-        self.__scroll_parser = self.SUBCOMMANDS.add_parser(
-            'scroll-text',
-            help='Scroll a text string on one or more of the matrices.',
-        )
-
-        self.scroll_parser.add_argument(
-            'input',
-            type=str,
-        )
+        from .commands.scroll_text import register_command
+        self.__scroll_parser = register_command(self)
 
     def __build(self):
         self.__building = True

--- a/is_matrix_forge/led_matrix/Scripts/led_matrix/arguments/commands/__init__.py
+++ b/is_matrix_forge/led_matrix/Scripts/led_matrix/arguments/commands/__init__.py
@@ -1,0 +1,17 @@
+"""
+
+
+Author: 
+    Inspyre Softworks
+
+Project:
+    IS-Matrix-Forge
+
+File: 
+    is_matrix_forge/led_matrix/Scripts/led_matrix/arguments/commands/__init__.py
+ 
+
+Description:
+    
+
+"""

--- a/is_matrix_forge/led_matrix/Scripts/led_matrix/arguments/commands/scroll_text.py
+++ b/is_matrix_forge/led_matrix/Scripts/led_matrix/arguments/commands/scroll_text.py
@@ -1,0 +1,35 @@
+from argparse import ArgumentParser
+
+
+DIRECTION_MAP = {
+    'up': 'vertical_down',
+    'down': 'vertical_up',
+    'h': 'horizontal'
+}
+
+COMMAND = 'scroll-text'
+
+HELP_TXT = 'Scroll text across a matrix.'
+
+
+def register_command(parser: ArgumentParser):
+    scroll_parser = parser.SUBCOMMANDS.add_parser(
+        COMMAND,
+        help=HELP_TXT
+    )
+
+    scroll_parser.add_argument(
+        'input',
+        type=str,
+        help='The text/string that you want to scroll.',
+    )
+
+    scroll_parser.add_argument(
+        '-d', '--direction',
+        type=str,
+        choices=DIRECTION_MAP.keys(),
+        default='up',
+        help='The direction to scroll the text in. Default is up.'
+    )
+
+    return scroll_parser

--- a/is_matrix_forge/led_matrix/controller/components/animation.py
+++ b/is_matrix_forge/led_matrix/controller/components/animation.py
@@ -82,7 +82,7 @@ class AnimationManager:
         if not isinstance(animation, Animation):
             raise TypeError(f'Expected Animation; got {type(animation)}')
         self._current_animation = animation
-        animation.play(devices=[self.device])
+        animation.play(devices=[self])
 
     # --- Text scrolling ------------------------------------------------------------
 
@@ -149,8 +149,8 @@ class AnimationManager:
         anim.loop = bool(loop)
         self._current_animation = anim
 
-        # IMPORTANT: play on the actual device object
-        anim.play(devices=[self.device])
+        # IMPORTANT: play using this controller so frames reuse the existing device connection
+        anim.play(devices=[self])
         return anim
 
     # --- Utilities ----------------------------------------------------------------

--- a/is_matrix_forge/led_matrix/display/animations/text_scroller.py
+++ b/is_matrix_forge/led_matrix/display/animations/text_scroller.py
@@ -44,7 +44,7 @@ class TextScroller:
         # -------- normalization helpers --------
 
     # Add near the top of TextScroller (just a tiny helper)
-    def _rows_to_cols(rows: List[List[int]]) -> List[List[int]]:
+    def _rows_to_cols(self, rows: List[List[int]]) -> List[List[int]]:
         if not rows:
             return []
         h, w = len(rows), len(rows[0])

--- a/is_matrix_forge/led_matrix/display/animations/text_scroller.py
+++ b/is_matrix_forge/led_matrix/display/animations/text_scroller.py
@@ -50,13 +50,59 @@ class TextScroller:
         h, w = len(rows), len(rows[0])
         return [[rows[r][c] for r in range(h)] for c in range(w)]
 
+    def _binary_flat_to_rows(self, flat: List[int]) -> GlyphRows:
+        """Interpret a flat binary list as row-major glyph data."""
+
+        if not flat:
+            return [[0]]
+
+        if not all(v in (0, 1) for v in flat):
+            raise ValueError("Flat glyph list must contain only 0/1 values")
+
+        total = len(flat)
+        max_width = min(MATRIX_WIDTH, total)
+        candidates: List[tuple[int, int]] = []
+        for width in range(1, max_width + 1):
+            if total % width:
+                continue
+            height = total // width
+            if height <= MATRIX_HEIGHT:
+                candidates.append((width, height))
+
+        if not candidates:
+            # Fallback: treat the glyph as a single row up to the display width.
+            return [flat[:max_width]]
+
+        preferred_widths = [5, 4, 6, 7, 8, 9, 3, 2, 1]
+        chosen: tuple[int, int] | None = None
+        for pref in preferred_widths:
+            for width, height in candidates:
+                if width == pref:
+                    chosen = (width, height)
+                    break
+            if chosen:
+                break
+
+        if chosen is None:
+            # Choose the candidate with the widest glyph to preserve detail.
+            chosen = max(candidates, key=lambda wh: (wh[0], wh[1]))
+
+        width, height = chosen
+        rows: GlyphRows = []
+        for r in range(height):
+            start = r * width
+            rows.append(flat[start:start + width])
+        return rows
+
     def _to_rows_cols(self, glyph: Any) -> GlyphRows:
         # Already rows×cols?
         if isinstance(glyph, list) and glyph and isinstance(glyph[0], list):
             return glyph
 
-        # 1-D list of bit-columns? (e.g., [0b010, 0b111, ...])
+        # 1-D list of ints? Distinguish flat binary glyphs from bit masks.
         if isinstance(glyph, list) and glyph and isinstance(glyph[0], int):
+            if all(isinstance(v, int) and v in (0, 1) for v in glyph):
+                return self._binary_flat_to_rows(glyph)
             return self._cols_mask_to_rows(glyph)
 
         # String rows like '01010'?
@@ -113,49 +159,6 @@ class TextScroller:
         source_map = getattr(self, '_rows_map', self.config.font_map)
 
         # --- local helpers -------------------------------------------------------
-        def to_rows_cols(g):
-            # already rows×cols?
-            if isinstance(g, list) and g and isinstance(g[0], list):
-                return g
-
-            # list of bit-mask columns, e.g., [0b010, 0b111, ...]
-            if isinstance(g, list) and g and isinstance(g[0], int):
-                height = max(1, max(c.bit_length() for c in g))
-                out = []
-                for r in range(height - 1, -1, -1):  # MSB = top row
-                    out.append([(c >> r) & 1 for c in g])
-                return out
-
-            # list of '01010' strings
-            if isinstance(g, list) and g and isinstance(g[0], str):
-                return [[1 if ch == '1' else 0 for ch in row] for row in g]
-
-            # model-like objects
-            if hasattr(g, 'rows'):
-                rows = getattr(g, 'rows')
-                if isinstance(rows, list) and rows and isinstance(rows[0], list):
-                    return rows
-            if hasattr(g, 'grid'):
-                grid = getattr(g, 'grid')
-                if isinstance(grid, list) and grid and isinstance(grid[0], list):
-                    return grid
-            if hasattr(g, 'cols'):
-                cols = getattr(g, 'cols')
-                if isinstance(cols, list) and cols and isinstance(cols[0], int):
-                    height = getattr(g, 'height', None)
-                    if height is None:
-                        height = max(1, max(c.bit_length() for c in cols))
-                    out = []
-                    for r in range(height - 1, -1, -1):
-                        out.append([(c >> r) & 1 for c in cols])
-                    return out
-
-            # blank/none-like
-            if g in (None, 0, []):
-                return [[0]]
-
-            raise TypeError(f'Unsupported glyph format: {type(g)!r}')
-
         def center_crop_rows(rows, target_h: int):
             h = len(rows)
             if h <= target_h:
@@ -191,7 +194,7 @@ class TextScroller:
             raw = source_map.get(ch)
             if raw is None:
                 raise ValueError(f'Character {ch!r} not found in font_map')
-            g = to_rows_cols(raw)
+            g = self._to_rows_cols(raw)
             if len(g) > MATRIX_HEIGHT:
                 if fit_mode == 'crop':
                     g = center_crop_rows(g, MATRIX_HEIGHT)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "IS-Matrix-Forge"
-version = "1.0.0-dev.21"
+version = "1.0.0-dev.23"
 
 description = ""
 authors = ["Taylor B. <t.blackstone@inspyre.tech>"]


### PR DESCRIPTION
## Summary
- ensure Animation.play passes the stop event through to each frame
- update Animation.play_frame to iterate per device and call Frame.play with the proper signature

## Testing
- pytest *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68cf0b40fa4c832da4e427207286c9a1

## Summary by Sourcery

Improve animation playback by fixing stop event handling and device iteration, enhance TextScroller to interpret flat binary glyphs, restructure scroll-text CLI registration with direction support, and bump the project version.

New Features:
- Support flat binary glyphs in TextScroller with a new conversion helper
- Allow specifying scroll direction in the scroll-text CLI command

Bug Fixes:
- Fix animation play loop to properly check and propagate the stop event
- Ensure play_frame iterates per device and passes the stop_event to each Frame.play call

Enhancements:
- Refactor TextScroller glyph handling by consolidating conversion logic into dedicated methods
- Move scroll-text parser setup into a separate commands module

Build:
- Bump version to 1.0.0-dev.23