### PR TITLE
Add framebuffer brightness retrieval

### DIFF
--- a/is_matrix_forge/led_matrix/commands/map.py
+++ b/is_matrix_forge/led_matrix/commands/map.py
@@ -29,6 +29,7 @@ class CommandVals(IntEnum):
     StageGreyCol = 0x07
     DrawGreyColBuffer = 0x08
     SetText = 0x09
+    GetAllBrightness = 0x0B
     StartGame = 0x10
     GameControl = 0x11
     GameStatus = 0x12

--- a/is_matrix_forge/led_matrix/controller/components/brightness/manager.py
+++ b/is_matrix_forge/led_matrix/controller/components/brightness/manager.py
@@ -34,7 +34,11 @@ from time import sleep
 from typing import Callable, Optional, Union
 
 from is_matrix_forge.common.helpers import percentage_to_value
-from is_matrix_forge.led_matrix.hardware import brightness as _set_brightness_raw
+from is_matrix_forge.led_matrix.constants import WIDTH as MATRIX_WIDTH, HEIGHT as MATRIX_HEIGHT
+from is_matrix_forge.led_matrix.hardware import (
+    brightness as _set_brightness_raw,
+    get_framebuffer_brightness as _get_framebuffer_brightness,
+)
 from is_matrix_forge.led_matrix.errors import InvalidBrightnessError
 from is_matrix_forge.led_matrix.controller.helpers.threading import synchronized
 
@@ -310,6 +314,17 @@ class BrightnessManager:
         except ValueError as e:
             raise InvalidBrightnessError(raw) from e
         self._brightness = pct
+
+    @synchronized(pause_breather=False)
+    def get_brightness_grid(self) -> list[list[int]]:
+        """Retrieve the per-pixel brightness values as a 9×34 grid."""
+        flat = _get_framebuffer_brightness(self.device)
+        grid = [[0] * MATRIX_HEIGHT for _ in range(MATRIX_WIDTH)]
+        for idx, level in enumerate(flat):
+            x = idx % MATRIX_WIDTH
+            y = idx // MATRIX_WIDTH
+            grid[x][y] = level
+        return grid
 
     # -------------------- Orchestration --------------------
 

--- a/tests/test_brightness_manager.py
+++ b/tests/test_brightness_manager.py
@@ -1,0 +1,58 @@
+import pytest
+
+from is_matrix_forge.led_matrix.constants import WIDTH, HEIGHT
+from is_matrix_forge.led_matrix.controller.base import DeviceBase
+from is_matrix_forge.led_matrix.controller.components.brightness import manager as brightness_manager_module
+from is_matrix_forge.led_matrix.controller.components.brightness.manager import (
+    BrightnessManager,
+)
+
+
+class DummyPort:
+    device = '/dev/ttyTEST'
+    name = 'Test Device'
+    serial_number = 'TEST1234'
+    location = '1-3.2'
+
+
+class DummyBrightnessController(BrightnessManager, DeviceBase):
+    def __init__(self):
+        super().__init__(device=DummyPort(), skip_init_brightness_set=True)
+
+
+def test_get_brightness_grid_returns_column_major(monkeypatch):
+    flat = list(range(WIDTH * HEIGHT))
+
+    monkeypatch.setattr(
+        brightness_manager_module,
+        '_get_framebuffer_brightness',
+        lambda dev: flat,
+    )
+
+    controller = DummyBrightnessController()
+
+    grid = controller.get_brightness_grid()
+
+    assert len(grid) == WIDTH
+    assert all(len(col) == HEIGHT for col in grid)
+
+    for idx, level in enumerate(flat):
+        x = idx % WIDTH
+        y = idx // WIDTH
+        assert grid[x][y] == level
+
+
+def test_get_brightness_grid_propagates_errors(monkeypatch):
+    def boom(dev):
+        raise IOError('bad read')
+
+    monkeypatch.setattr(
+        brightness_manager_module,
+        '_get_framebuffer_brightness',
+        boom,
+    )
+
+    controller = DummyBrightnessController()
+
+    with pytest.raises(IOError):
+        controller.get_brightness_grid()


### PR DESCRIPTION
## Summary
- add the firmware command constant for retrieving the full brightness framebuffer
- extend the hardware layer with framebuffer brightness querying and adjustable response sizes
- expose a `get_brightness_grid` helper on `BrightnessManager` and cover it with unit tests

## Testing
- PYTHONPATH=. pytest tests/test_brightness_manager.py -q
- PYTHONPATH=. pytest *(fails: existing suite expectations around controller initialization and grid helpers outside this change)*

------
https://chatgpt.com/codex/tasks/task_e_68d045a08460832dbbb8f18041b42632

## Summary by Sourcery

Enable retrieval of the full framebuffer brightness data by introducing a new firmware command and hardware API, expose a grid-based helper in the brightness manager, and cover the feature with unit tests

New Features:
- Add GetAllBrightness firmware command to retrieve full framebuffer brightness
- Implement get_framebuffer_brightness in hardware layer to fetch per-pixel brightness data
- Expose get_brightness_grid helper in BrightnessManager to return a 2D brightness grid

Enhancements:
- Define FRAMEBUFFER_SIZE constant and update send_command to accept custom response_size

Tests:
- Add unit tests for get_brightness_grid normal operation and error propagation