### PR TITLE
Refine controller property tests

### DIFF
--- a/tests/test_controller_properties.py
+++ b/tests/test_controller_properties.py
@@ -1,195 +1,207 @@
-"""
-Tests for LEDMatrixController properties, specifically side_of_keyboard and slot.
+"""Tests for LED matrix controller side and slot helper logic."""
 
-Note: These tests verify the logic of find_leftmost_matrix and find_rightmost_matrix
-using mock controller objects that implement the required properties.
-"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Iterable, Optional
+
 import pytest
 
-
-def test_side_of_keyboard_and_slot_properties():
-    """Test that side_of_keyboard and slot properties work correctly with mock objects."""
-    from is_matrix_forge.led_matrix.constants import SLOT_MAP
-    
-    # Simple mock controller to test the property logic
-    class MockController:
-        def __init__(self, location):
-            self.device_location = location
-            loc_info = SLOT_MAP.get(location)
-            if loc_info:
-                self._side = loc_info['side']
-                self._slot = loc_info['slot']
-        
-        @property
-        def side_of_keyboard(self):
-            return self._side
-        
-        @property
-        def slot(self):
-            return self._slot
-    
-    # Test left side, slot 1
-    ctrl_l1 = MockController('1-4.2')
-    assert ctrl_l1.side_of_keyboard == 'left'
-    assert ctrl_l1.slot == 1
-    
-    # Test right side, slot 2  
-    ctrl_r2 = MockController('1-3.3')
-    assert ctrl_r2.side_of_keyboard == 'right'
-    assert ctrl_r2.slot == 2
+from is_matrix_forge.led_matrix.constants import SLOT_MAP
 
 
-def test_find_leftmost_matrix():
-    """Test that find_leftmost_matrix correctly identifies the leftmost device."""
-    # We can't import the actual functions due to missing dependencies in test environment,
-    # but we can verify the logic by implementing it with our mock objects
-    from is_matrix_forge.led_matrix.constants import SLOT_MAP
-    
-    class MockController:
-        def __init__(self, location, name):
-            self.device_location = location
-            self.device_name = name
-            loc_info = SLOT_MAP.get(location)
-            if loc_info:
-                self._side = loc_info['side']
-                self._slot = loc_info['slot']
-        
-        @property
-        def side_of_keyboard(self):
-            return self._side
-        
-        @property
-        def slot(self):
-            return self._slot
-    
-    controllers = [
-        MockController('1-4.3', 'L2'),  # L2
-        MockController('1-3.2', 'R1'),  # R1
-        MockController('1-4.2', 'L1'),  # L1 - should be leftmost
-    ]
-    
-    # Replicate the find_leftmost_matrix logic
-    left_devices = [m for m in controllers if m.side_of_keyboard == 'left']
-    leftmost = min(left_devices, key=lambda m: m.slot)
-    
-    assert leftmost is not None
-    assert leftmost.side_of_keyboard == 'left'
-    assert leftmost.slot == 1
-    assert leftmost.device_name == 'L1'
+@dataclass(frozen=True)
+class MockDevice:
+    """Emulate the ``ListPortInfo`` attributes accessed by ``DeviceBase``."""
+
+    location: str
+    name: str
+    serial_number: str
 
 
-def test_find_rightmost_matrix():
-    """Test that find_rightmost_matrix correctly identifies the rightmost device."""
-    from is_matrix_forge.led_matrix.constants import SLOT_MAP
-    
-    class MockController:
-        def __init__(self, location, name):
-            self.device_location = location
-            self.device_name = name
-            loc_info = SLOT_MAP.get(location)
-            if loc_info:
-                self._side = loc_info['side']
-                self._slot = loc_info['slot']
-        
-        @property
-        def side_of_keyboard(self):
-            return self._side
-        
-        @property
-        def slot(self):
-            return self._slot
-    
-    controllers = [
-        MockController('1-4.2', 'L1'),  # L1
-        MockController('1-3.2', 'R1'),  # R1
-        MockController('1-3.3', 'R2'),  # R2 - should be rightmost
-    ]
-    
-    # Replicate the find_rightmost_matrix logic
-    right_devices = [m for m in controllers if m.side_of_keyboard == 'right']
-    rightmost = max(right_devices, key=lambda m: m.slot)
-    
-    assert rightmost is not None
-    assert rightmost.side_of_keyboard == 'right'
-    assert rightmost.slot == 2
-    assert rightmost.device_name == 'R2'
+class MockController:
+    """Rich controller mock mirroring the ``DeviceBase`` interface used in scripts."""
+
+    def __init__(
+        self,
+        location: str,
+        name: Optional[str] = None,
+        serial_number: Optional[str] = None,
+    ) -> None:
+        if (location_info := SLOT_MAP.get(location)) is None:
+            msg = f"Unknown controller location: {location!r}"
+            raise ValueError(msg)
+
+        controller_name = name or location
+        self._device = MockDevice(
+            location=location,
+            name=controller_name,
+            serial_number=serial_number or f"SN-{controller_name}",
+        )
+        self._location_info = location_info
+
+    # --- public attributes matching ``LEDMatrixController`` ---
+    @property
+    def device(self) -> MockDevice:
+        return self._device
+
+    @property
+    def device_location(self) -> str:
+        return self._device.location
+
+    @property
+    def name(self) -> str:
+        return self._device.name
+
+    @property
+    def device_name(self) -> str:
+        return self._device.name
+
+    @property
+    def serial_number(self) -> str:
+        return self._device.serial_number
+
+    # --- derived helpers ---
+    @property
+    def location(self) -> dict[str, object]:
+        return self._location_info
+
+    @property
+    def location_abbrev(self) -> str:
+        return self._location_info["abbrev"]
+
+    @property
+    def side_of_keyboard(self) -> str:
+        return self._location_info["side"]
+
+    @property
+    def slot(self) -> int:
+        return self._location_info["slot"]
 
 
-def test_find_leftmost_with_only_right_devices():
-    """Test that find_leftmost_matrix falls back to right devices when no left devices exist."""
-    from is_matrix_forge.led_matrix.constants import SLOT_MAP
-    
-    class MockController:
-        def __init__(self, location, name):
-            self.device_location = location
-            self.device_name = name
-            loc_info = SLOT_MAP.get(location)
-            if loc_info:
-                self._side = loc_info['side']
-                self._slot = loc_info['slot']
-        
-        @property
-        def side_of_keyboard(self):
-            return self._side
-        
-        @property
-        def slot(self):
-            return self._slot
-    
-    controllers = [
-        MockController('1-3.3', 'R2'),  # R2
-        MockController('1-3.2', 'R1'),  # R1 - should be leftmost (fallback)
-    ]
-    
-    # Replicate the find_leftmost_matrix logic with fallback
-    left_devices = [m for m in controllers if m.side_of_keyboard == 'left']
-    if left_devices:
-        leftmost = min(left_devices, key=lambda m: m.slot)
-    else:
-        # Fallback to right devices
-        right_devices = [m for m in controllers if m.side_of_keyboard == 'right']
-        leftmost = min(right_devices, key=lambda m: m.slot) if right_devices else None
-    
-    assert leftmost is not None
-    assert leftmost.side_of_keyboard == 'right'
-    assert leftmost.slot == 1
+def select_leftmost(controllers: Iterable[MockController]) -> Optional[MockController]:
+    """Replicate ``find_leftmost_matrix`` selection logic for mock controllers."""
+
+    if left_devices := [c for c in controllers if c.side_of_keyboard == "left"]:
+        return min(left_devices, key=lambda controller: controller.slot)
+    return min(
+        (c for c in controllers if c.side_of_keyboard == "right"),
+        key=lambda controller: controller.slot,
+        default=None,
+    )
 
 
-def test_find_rightmost_with_only_left_devices():
-    """Test that find_rightmost_matrix falls back to left devices when no right devices exist."""
-    from is_matrix_forge.led_matrix.constants import SLOT_MAP
-    
-    class MockController:
-        def __init__(self, location, name):
-            self.device_location = location
-            self.device_name = name
-            loc_info = SLOT_MAP.get(location)
-            if loc_info:
-                self._side = loc_info['side']
-                self._slot = loc_info['slot']
-        
-        @property
-        def side_of_keyboard(self):
-            return self._side
-        
-        @property
-        def slot(self):
-            return self._slot
-    
-    controllers = [
-        MockController('1-4.2', 'L1'),  # L1
-        MockController('1-4.3', 'L2'),  # L2 - should be rightmost (fallback)
-    ]
-    
-    # Replicate the find_rightmost_matrix logic with fallback
-    right_devices = [m for m in controllers if m.side_of_keyboard == 'right']
-    if right_devices:
-        rightmost = max(right_devices, key=lambda m: m.slot)
-    else:
-        # Fallback to left devices
-        left_devices = [m for m in controllers if m.side_of_keyboard == 'left']
-        rightmost = max(left_devices, key=lambda m: m.slot) if left_devices else None
-    
-    assert rightmost is not None
-    assert rightmost.side_of_keyboard == 'left'
-    assert rightmost.slot == 2
+def select_rightmost(controllers: Iterable[MockController]) -> Optional[MockController]:
+    """Replicate ``find_rightmost_matrix`` selection logic for mock controllers."""
+
+    if right_devices := [c for c in controllers if c.side_of_keyboard == "right"]:
+        return max(right_devices, key=lambda controller: controller.slot)
+    return max(
+        (c for c in controllers if c.side_of_keyboard == "left"),
+        key=lambda controller: controller.slot,
+        default=None,
+    )
+
+
+def assert_controller_matches(
+    controller: Optional[MockController], *, name: Optional[str], side: Optional[str], slot: Optional[int], location: Optional[str]
+) -> None:
+    """Verify that a controller matches the expected attributes."""
+
+    if name is None:
+        assert controller is None
+        return
+    assert controller is not None
+    assert controller.name == name
+    assert controller.device_location == location
+    assert controller.side_of_keyboard == side
+    assert controller.slot == slot
+    assert controller.location["side"] == side
+    assert controller.location["slot"] == slot
+    abbrev_prefix = "L" if side == "left" else "R"
+    assert controller.location_abbrev == f"{abbrev_prefix}{slot}"
+
+
+@pytest.mark.parametrize(
+    ("location", "expected_side", "expected_slot", "expected_abbrev"),
+    [
+        ("1-4.2", "left", 1, "L1"),
+        ("1-3.3", "right", 2, "R2"),
+    ],
+)
+def test_side_of_keyboard_and_slot_properties(
+    location: str, expected_side: str, expected_slot: int, expected_abbrev: str
+) -> None:
+    """Controllers expose the expected side and slot based on the slot map."""
+
+    controller = MockController(location)
+    assert controller.side_of_keyboard == expected_side
+    assert controller.slot == expected_slot
+    assert controller.location == SLOT_MAP[location]
+    assert controller.location_abbrev == expected_abbrev
+
+
+@pytest.mark.parametrize(
+    "controllers, expected",
+    [
+        pytest.param(
+            [
+                MockController("1-4.3", "L2"),
+                MockController("1-3.2", "R1"),
+                MockController("1-4.2", "L1"),
+            ],
+            {"name": "L1", "side": "left", "slot": 1, "location": "1-4.2"},
+            id="prefers-left-devices",
+        ),
+        pytest.param(
+            [
+                MockController("1-3.3", "R2"),
+                MockController("1-3.2", "R1"),
+            ],
+            {"name": "R1", "side": "right", "slot": 1, "location": "1-3.2"},
+            id="fallback-to-right-devices",
+        ),
+        pytest.param(
+            [],
+            {"name": None, "side": None, "slot": None, "location": None},
+            id="no-devices",
+        ),
+    ],
+)
+def test_find_leftmost_matrix(controllers: list[MockController], expected: dict[str, Optional[object]]) -> None:
+    """Leftmost selection prefers left devices and falls back appropriately."""
+
+    assert_controller_matches(select_leftmost(controllers), **expected)
+
+
+@pytest.mark.parametrize(
+    "controllers, expected",
+    [
+        pytest.param(
+            [
+                MockController("1-4.2", "L1"),
+                MockController("1-3.2", "R1"),
+                MockController("1-3.3", "R2"),
+            ],
+            {"name": "R2", "side": "right", "slot": 2, "location": "1-3.3"},
+            id="prefers-right-devices",
+        ),
+        pytest.param(
+            [
+                MockController("1-4.2", "L1"),
+                MockController("1-4.3", "L2"),
+            ],
+            {"name": "L2", "side": "left", "slot": 2, "location": "1-4.3"},
+            id="fallback-to-left-devices",
+        ),
+        pytest.param(
+            [],
+            {"name": None, "side": None, "slot": None, "location": None},
+            id="no-devices",
+        ),
+    ],
+)
+def test_find_rightmost_matrix(controllers: list[MockController], expected: dict[str, Optional[object]]) -> None:
+    """Rightmost selection prefers right devices and falls back appropriately."""
+
+    assert_controller_matches(select_rightmost(controllers), **expected)


### PR DESCRIPTION
## Summary
- expand the shared controller mock to mirror the DeviceBase interface, including device metadata and location helpers
- keep the parametrized property and selection scenarios that cover fallback and empty-controller cases while asserting the richer attributes

## Testing
- `pytest tests/test_controller_properties.py` *(fails: command not found in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e2d1d15c68832db4539ed6d359b09f