### PR TITLE
Fix led-matrix CLI help and identify command wiring

### DIFF
--- a/is_matrix_forge/led_matrix/Scripts/identify_matrices.py
+++ b/is_matrix_forge/led_matrix/Scripts/identify_matrices.py
@@ -130,8 +130,14 @@ def main(arguments: argparse.Namespace) -> List[Thread]:
 
     if arguments.only_right:
         selected = [device for device in [find_rightmost_matrix(selected)] if device]
+        if not selected:
+            print("Error: No rightmost matrix found in the selection.")
+            return
     elif arguments.only_left:
         selected = [device for device in [find_leftmost_matrix(selected)] if device]
+        if not selected:
+            print("Error: No leftmost matrix found in the selection.")
+            return
 
     threads = [
         Thread(

--- a/is_matrix_forge/led_matrix/Scripts/identify_matrices.py
+++ b/is_matrix_forge/led_matrix/Scripts/identify_matrices.py
@@ -20,7 +20,7 @@ Since:
 import argparse
 from argparse import ArgumentParser
 from threading import Thread
-from typing import List, Optional, Union
+from typing import List, Optional
 
 from is_matrix_forge.led_matrix.controller.controller import LEDMatrixController
 from is_matrix_forge.led_matrix.constants import DEVICES
@@ -75,161 +75,85 @@ def find_rightmost_matrix(matrices: List[LEDMatrixController]) -> Optional[LEDMa
     return max(left_devices, key=lambda m: m.slot) if left_devices else None
 
 
-class Arguments(ArgumentParser):
-    def __init__(self):
-        super().__init__('IdentifyLEDMatrices')
-        self.__parsed = None
+def build_parser() -> ArgumentParser:
+    parser = ArgumentParser('IdentifyLEDMatrices')
 
-        # Set up the arguments
-        self.add_argument(
-            '--runtime', '-t',
-            action='store',
-            default=DEFAULT_RUNTIME,
-            help='The total runtime'
-        )
+    parser.add_argument(
+        '--runtime', '-t',
+        action='store',
+        type=float,
+        default=float(DEFAULT_RUNTIME),
+        help='The total runtime in seconds.',
+    )
 
-        self.add_argument(
-            '--skip-clear',
-            action='store_true',
-            default=False,
-            help='Skip clearing LEDs'
-        )
+    parser.add_argument(
+        '--skip-clear',
+        action='store_true',
+        default=False,
+        help='Skip clearing LEDs.',
+    )
 
-        self.add_argument(
-            '-c', '--cycle-count',
-            action='store',
-            type=int,
-            default=DEFAULT_CYCLES,
-            help='The number of cycles to run per message, for each selected device.'
-        )
+    parser.add_argument(
+        '-c', '--cycle-count',
+        action='store',
+        type=int,
+        default=DEFAULT_CYCLES,
+        help='The number of cycles to run per message, for each selected device.',
+    )
 
-        # Set up the mutually exclusive arguments for the left and right matrices
-        left_right = self.add_mutually_exclusive_group()
+    left_right = parser.add_mutually_exclusive_group()
+    left_right.add_argument(
+        '-R', '--only-right',
+        action='store_true',
+        default=False,
+        help='Only display identifying information for/on the rightmost matrix.',
+    )
 
-        left_right.add_argument(
-            '-R', '--only-right',
-            action='store_true',
-            default=False,
-            help='Only display identifying information for/on the rightmost matrix.'
-        )
+    left_right.add_argument(
+        '-L', '--only-left',
+        action='store_true',
+        default=False,
+        help='Only display identifying information for/on the leftmost matrix.',
+    )
 
-        left_right.add_argument(
-            '-L', '--only-left',
-            action='store_true',
-            default=False,
-            help='Only display identifying information for/on the leftmost matrix.'
-        )
-
-    @property
-    def parsed(self) -> Optional[argparse.Namespace]:
-        """
-        The parsed arguments (if they've been parsed).
-
-        Returns:
-            argparse.Namespace:
-                The parsed arguments.
-
-            None:
-                If the arguments have not yet been parsed.
-        """
-        return self.__parsed
-
-    def parse_args(self, *args, **kwargs):
-        """
-        (Overrides the parent method, since we need to cache the parsed arguments. Does only that and then calls the
-        parent method.)
-
-        Parameters:
-            *args:
-            **kwargs:
-
-        Returns:
-            argparse.Namespace:
-                The parsed arguments
-        """
-        self.__parsed = super().parse_args(*args, **kwargs)
-        return self.__parsed
+    return parser
 
 
-def main(
-    runtime:         Optional[Union[int, float]]  = None,
-    only_left:       Optional[bool]               = None,
-    only_right:      Optional[bool]               = None,
-    skip_clear:      Optional[bool]               = None,
-    cycle_count:     Optional[int]                = None,
-    argument_parser: Optional[ArgumentParser]     = None,
-    arguments:       Optional[argparse.Namespace] = None,
-):
-    """
-    The main function of the script.
+def parse_args(args: Optional[List[str]] = None) -> argparse.Namespace:
+    return build_parser().parse_args(args=args)
 
-    Parameters:
-        runtime (Optional[Union[int, float]]):
-            The total runtime in seconds.
 
-        only_left (Optional[bool]):
-            Only display identifying information for/on the leftmost matrix.
-
-        only_right (Optional[bool]):
-            Only display identifying information for/on the rightmost matrix.
-
-        skip_clear (Optional[bool]):
-            Skip clearing LEDs.
-
-        cycle_count (Optional[int]):
-            The number of cycles to run per message, for each selected device.
-
-        argument_parser (Optional[ArgumentParser]):
-            The argument parser to use. If not provided, the default parser will be used.
-
-    Returns:
-        List[Thread]:
-            A list of threads, one for each LED matrix being identified.
-    """
-    parser = argument_parser or ARGS
-    parsed = arguments or parser.parse_args()
+def main(arguments: argparse.Namespace) -> List[Thread]:
+    """Execute the identification routine based on parsed arguments."""
 
     selected = [LEDMatrixController(device, 100, thread_safe=True) for device in DEVICES]
 
-    if skip_clear is None:
-        skip_clear = parsed.skip_clear
+    if arguments.only_right:
+        selected = [device for device in [find_rightmost_matrix(selected)] if device]
+    elif arguments.only_left:
+        selected = [device for device in [find_leftmost_matrix(selected)] if device]
 
-    if only_left is None:
-        only_left = parsed.only_left
-
-    if only_right is None:
-        only_right = parsed.only_right
-
-    if only_right:
-        selected = [find_rightmost_matrix(selected)]
-    elif only_left:
-        selected = [find_leftmost_matrix(selected)]
-
-    cycle_count = parsed.cycle_count if cycle_count is None else cycle_count
-
-    if runtime is None:
-        runtime = parsed.runtime
-
-    threads = []
-
-    threads.extend(
+    threads = [
         Thread(
             target=device.identify,
             kwargs={
-                'skip_clear': skip_clear,
-                'duration':   runtime,
-                'cycles':     cycle_count
+                'skip_clear': arguments.skip_clear,
+                'duration':   arguments.runtime,
+                'cycles':     arguments.cycle_count,
             },
         )
         for device in selected
-    )
-    for t in threads:
-        t.start()
+    ]
+
+    for thread in threads:
+        thread.start()
 
     return threads
 
 
-ARGS = Arguments()
+def run_from_cli(args: Optional[List[str]] = None) -> List[Thread]:
+    return main(parse_args(args=args))
+
 
 if __name__ == '__main__':
-    threads = main(argument_parser=ARGS)
+    run_from_cli()

--- a/is_matrix_forge/led_matrix/Scripts/identify_matrices.py
+++ b/is_matrix_forge/led_matrix/Scripts/identify_matrices.py
@@ -158,6 +158,7 @@ def main(
     skip_clear:      Optional[bool]               = None,
     cycle_count:     Optional[int]                = None,
     argument_parser: Optional[ArgumentParser]     = None,
+    arguments:       Optional[argparse.Namespace] = None,
 ):
     """
     The main function of the script.
@@ -185,26 +186,29 @@ def main(
         List[Thread]:
             A list of threads, one for each LED matrix being identified.
     """
+    parser = argument_parser or ARGS
+    parsed = arguments or parser.parse_args()
+
     selected = [LEDMatrixController(device, 100, thread_safe=True) for device in DEVICES]
 
-    if not skip_clear:
-        skip_clear = ARGS.parsed.skip_clear
+    if skip_clear is None:
+        skip_clear = parsed.skip_clear
 
     if only_left is None:
-        only_left = ARGS.parsed.only_left
+        only_left = parsed.only_left
 
     if only_right is None:
-        only_right = ARGS.parsed.only_right
+        only_right = parsed.only_right
 
     if only_right:
         selected = [find_rightmost_matrix(selected)]
     elif only_left:
         selected = [find_leftmost_matrix(selected)]
 
-    cycle_count = ARGS.parsed.cycle_count if cycle_count is None else cycle_count
+    cycle_count = parsed.cycle_count if cycle_count is None else cycle_count
 
     if runtime is None:
-        runtime = ARGS.parsed.runtime
+        runtime = parsed.runtime
 
     threads = []
 
@@ -225,8 +229,7 @@ def main(
     return threads
 
 
-ARGS   = Arguments()
-PARSED = ARGS.parse_args()
+ARGS = Arguments()
 
 if __name__ == '__main__':
-    threads = main()
+    threads = main(argument_parser=ARGS)

--- a/is_matrix_forge/led_matrix/Scripts/led_matrix/arguments/__init__.py
+++ b/is_matrix_forge/led_matrix/Scripts/led_matrix/arguments/__init__.py
@@ -67,10 +67,8 @@ class Arguments(ArgumentParser):
         self.__building = True
 
         self.__build_identify_matrices()
-        print('built identify matrices command')
 
         self.__build_scroll_text()
-        print('built scroll text command')
 
         self.__building = False
         self.__built    = True

--- a/is_matrix_forge/led_matrix/Scripts/led_matrix/arguments/__init__.py
+++ b/is_matrix_forge/led_matrix/Scripts/led_matrix/arguments/__init__.py
@@ -20,6 +20,20 @@ class Arguments(ArgumentParser):
         self.__identify_parser = None
         self.__scroll_parser   = None
 
+        selection_group = self.add_mutually_exclusive_group()
+        selection_group.add_argument(
+            '-L', '--only-left',
+            action='store_true',
+            default=False,
+            help='Only target the leftmost matrix when executing commands.'
+        )
+        selection_group.add_argument(
+            '-R', '--only-right',
+            action='store_true',
+            default=False,
+            help='Only target the rightmost matrix when executing commands.'
+        )
+
         self.SUBCOMMANDS = self.add_subparsers(
             dest='subcommand',
             required=True,

--- a/is_matrix_forge/led_matrix/Scripts/led_matrix/arguments/__init__.py
+++ b/is_matrix_forge/led_matrix/Scripts/led_matrix/arguments/__init__.py
@@ -19,6 +19,7 @@ class Arguments(ArgumentParser):
         self.__parsed          = None
         self.__identify_parser = None
         self.__scroll_parser   = None
+        self.__display_parser  = None
 
         selection_group = self.add_mutually_exclusive_group()
         selection_group.add_argument(
@@ -69,6 +70,10 @@ class Arguments(ArgumentParser):
     def scroll_parser(self):
         return self.__scroll_parser
 
+    @property
+    def display_parser(self):
+        return self.__display_parser
+
     def __build_identify_matrices(self):
         from .commands.identify_matrices import register_command
         self.__identify_parser = register_command(self)
@@ -77,12 +82,18 @@ class Arguments(ArgumentParser):
         from .commands.scroll_text import register_command
         self.__scroll_parser = register_command(self)
 
+    def __build_display_text(self):
+        from .commands.display_text import register_command
+        self.__display_parser = register_command(self)
+
     def __build(self):
         self.__building = True
 
         self.__build_identify_matrices()
 
         self.__build_scroll_text()
+
+        self.__build_display_text()
 
         self.__building = False
         self.__built    = True

--- a/is_matrix_forge/led_matrix/Scripts/led_matrix/arguments/commands/display_text.py
+++ b/is_matrix_forge/led_matrix/Scripts/led_matrix/arguments/commands/display_text.py
@@ -1,0 +1,37 @@
+from argparse import ArgumentParser
+
+
+COMMAND = 'display-text'
+
+
+HELP_TXT = 'Display a static string on the matrix until interrupted.'
+
+
+def register_command(parser: ArgumentParser):
+    display_parser = parser.SUBCOMMANDS.add_parser(
+        COMMAND,
+        help=HELP_TXT,
+    )
+
+    display_parser.add_argument(
+        'text',
+        type=str,
+        help='The text/string that you want to display.',
+    )
+
+    display_parser.add_argument(
+        '--run-for',
+        type=float,
+        default=None,
+        metavar='SECONDS',
+        help='Automatically stop after the specified number of seconds. Defaults to running until interrupted.',
+    )
+
+    display_parser.add_argument(
+        '--skip-clear',
+        action='store_true',
+        default=False,
+        help='Do not clear the matrix after the display stops.',
+    )
+
+    return display_parser

--- a/is_matrix_forge/led_matrix/Scripts/led_matrix/arguments/commands/identify_matrices.py
+++ b/is_matrix_forge/led_matrix/Scripts/led_matrix/arguments/commands/identify_matrices.py
@@ -5,15 +5,10 @@ from ....identify_matrices import DEFAULT_CYCLES, DEFAULT_RUNTIME
 COMMAND = 'identify-matrices'
 
 
-CONTROLLER_MAP = {
-    'all': 'all',
-    'l': 'leftmost',
-    'r': 'rightmost'
-}
-
-
-HELP_TXT = ('Each found and configured controller will run the identification routine. This will have the device '
-            'display it\'s own information.')
+HELP_TXT = (
+    'Each found and configured controller will run the identification routine. '
+    "Use the global '--only-left/--only-right' flags to limit which matrices participate."
+)
 
 
 def register_command(parser: ArgumentParser):
@@ -42,23 +37,6 @@ def register_command(parser: ArgumentParser):
         type=int,
         default=DEFAULT_CYCLES,
         help='The number of cycles to run per message, for each selected device.'
-    )
-
-    # Set up the mutually exclusive arguments for the left and right matrices
-    left_right = id_parser.add_mutually_exclusive_group()
-
-    left_right.add_argument(
-        '-R', '--only-right',
-        action='store_true',
-        default=False,
-        help='Only display identifying information for/on the rightmost matrix.'
-    )
-
-    left_right.add_argument(
-        '-L', '--only-left',
-        action='store_true',
-        default=False,
-        help='Only display identifying information for/on the leftmost matrix.'
     )
 
     return id_parser

--- a/is_matrix_forge/led_matrix/Scripts/led_matrix/arguments/commands/identify_matrices.py
+++ b/is_matrix_forge/led_matrix/Scripts/led_matrix/arguments/commands/identify_matrices.py
@@ -61,3 +61,4 @@ def register_command(parser: ArgumentParser):
         help='Only display identifying information for/on the leftmost matrix.'
     )
 
+    return id_parser


### PR DESCRIPTION
## Summary
- stop parsing identify-matrices arguments at import time and return the subparser so the led-matrix CLI can initialise cleanly
- wire the identify-matrices subcommand to the CLI, honouring selection flags and reusing controller identify parameters
- remove noisy debug prints from argument construction for cleaner help output

## Testing
- PYTHONPATH=. pytest *(fails: ModuleNotFoundError for inspyre_toolbox.path_man / inspyre_toolbox.syntactic_sweets.classes)*

------
https://chatgpt.com/codex/tasks/task_e_68ecada1f47c832d8c1860b0ce7d04df

## Summary by Sourcery

Fix and extend the led-matrix CLI by properly wiring subcommands, improving argument parsing, adding execution guards, and cleaning up help output.

New Features:
- Add a display-text subcommand with --run-for duration and --skip-clear options
- Wire the identify-matrices subcommand into the main CLI and reuse its argument settings

Enhancements:
- Centralize subcommand registration in the main function and remove import-time argument parsing
- Introduce thread-based guards for scroll-text and display-text commands with automatic cleanup
- Implement controller filtering by --only-left/--only-right flags and improved error messages for unavailable or unmatched matrices
- Remove noisy debug prints from argument construction for cleaner CLI help