### PR TITLE
Fix composite grid helpers and deduplicate inputmodule exports

### DIFF
--- a/is_matrix_forge/inputmodule/__init__.py
+++ b/is_matrix_forge/inputmodule/__init__.py
@@ -1,164 +1,24 @@
-from enum import IntEnum
-import serial
+from is_matrix_forge.led_matrix.commands.map import CommandVals
+from is_matrix_forge.led_matrix.constants import (
+    DISCONNECTED_DEVS,
+    FWK_MAGIC,
+    PID as LED_MATRIX_PID,
+    RESPONSE_SIZE,
+    VID as FWK_VID,
+)
+from is_matrix_forge.led_matrix.display.patterns.built_in.stencils.res import PatternVals
+from is_matrix_forge.led_matrix.hardware import (
+    Game,
+    GameControlVal,
+    GameOfLifeStartParam,
+    bootloader_jump,
+    brightness,
+    get_brightness,
+    get_version,
+    send_command,
+    send_command_raw,
+)
+from is_matrix_forge.led_matrix.helpers import disconnect_dev, send_serial
 
-DISCONNECTED_DEVS = []
-FWK_MAGIC = [0x32, 0xAC]
-FWK_VID = 0x32AC
-LED_MATRIX_PID = 0x20
 QTPY_PID = 0x001F
 INPUTMODULE_PIDS = [LED_MATRIX_PID, QTPY_PID]
-
-
-def disconnect_dev(dev):
-    """
-    Disconnect the device from the system.
-
-    Parameters:
-        dev (str):
-            The device to disconnect.
-    """
-    global DISCONNECTED_DEVS
-    if dev in DISCONNECTED_DEVS:
-        return
-    DISCONNECTED_DEVS.append(dev)
-
-
-class CommandVals(IntEnum):
-    Brightness = 0x00
-    Pattern = 0x01
-    BootloaderReset = 0x02
-    Sleep = 0x03
-    Animate = 0x04
-    Panic = 0x05
-    Draw = 0x06
-    StageGreyCol = 0x07
-    DrawGreyColBuffer = 0x08
-    SetText = 0x09
-    StartGame = 0x10
-    GameControl = 0x11
-    GameStatus = 0x12
-    SetColor = 0x13
-    DisplayOn = 0x14
-    InvertScreen = 0x15
-    SetPixelColumn = 0x16
-    FlushFramebuffer = 0x17
-    ClearRam = 0x18
-    ScreenSaver = 0x19
-    SetFps = 0x1A
-    SetPowerMode = 0x1B
-    PwmFreq = 0x1E
-    DebugMode = 0x1F
-    Version = 0x20
-
-
-class Game(IntEnum):
-    Snake = 0x00
-    Pong = 0x01
-    Tetris = 0x02
-    GameOfLife = 0x03
-
-
-class PatternVals(IntEnum):
-    Percentage = 0x00
-    Gradient = 0x01
-    DoubleGradient = 0x02
-    DisplayLotus = 0x03
-    ZigZag = 0x04
-    FullBrightness = 0x05
-    DisplayPanic = 0x06
-    DisplayLotus2 = 0x07
-
-
-class GameOfLifeStartParam(IntEnum):
-    Currentmatrix = 0x00
-    Pattern1 = 0x01
-    Blinker = 0x02
-    Toad = 0x03
-    Beacon = 0x04
-    Glider = 0x05
-
-    def __str__(self):
-        return self.name.lower()
-
-    def __repr__(self):
-        return str(self)
-
-    @staticmethod
-    def argparse(s):
-        try:
-            return GameOfLifeStartParam[s.lower().capitalize()]
-        except KeyError:
-            return s
-
-
-class GameControlVal(IntEnum):
-    Up = 0
-    Down = 1
-    Left = 2
-    Right = 3
-    Quit = 4
-
-
-RESPONSE_SIZE = 32
-
-
-def bootloader_jump(dev):
-    """Reboot into the bootloader to flash new firmware"""
-    send_command(dev, CommandVals.BootloaderReset, [0x00])
-
-
-def brightness(dev, b: int):
-    """Adjust the brightness scaling of the entire screen."""
-    send_command(dev, CommandVals.Brightness, [b])
-
-
-def get_brightness(dev):
-    """Adjust the brightness scaling of the entire screen."""
-    res = send_command(dev, CommandVals.Brightness, with_response=True)
-    return int(res[0])
-
-
-def get_version(dev):
-    """Get the device's firmware version"""
-    res = send_command(dev, CommandVals.Version, with_response=True)
-    if not res:
-        return 'Unknown'
-    major = res[0]
-    minor = (res[1] & 0xF0) >> 4
-    patch = res[1] & 0xF
-    pre_release = res[2]
-
-    version = f"{major}.{minor}.{patch}"
-    if pre_release:
-        version += " (Pre-release)"
-    return version
-
-
-def send_command(dev, command, parameters=[], with_response=False):
-    return send_command_raw(dev, FWK_MAGIC + [command] + parameters, with_response)
-
-
-def send_command_raw(dev, command, with_response=False):
-    """Send a command to the device.
-    Opens new serial connection every time"""
-    # print(f"Sending command: {command}")
-    try:
-        with serial.Serial(dev.device, 115200) as s:
-            s.write(command)
-
-            if with_response:
-                res = s.read(RESPONSE_SIZE)
-                # print(f"Received: {res}")
-                return res
-    except (IOError, OSError) as _ex:
-        disconnect_dev(dev.device)
-        # print("Error: ", ex)
-
-
-def send_serial(dev, s, command):
-    """Send serial command by using existing serial connection"""
-    try:
-        s.write(command)
-    except (IOError, OSError) as _ex:
-        disconnect_dev(dev.device)
-        # print("Error: ", ex)

--- a/is_matrix_forge/inputmodule/b1display.py
+++ b/is_matrix_forge/inputmodule/b1display.py
@@ -1,6 +1,6 @@
 import sys
 
-from inputmodule.inputmodule import send_command, CommandVals, FWK_MAGIC
+from . import CommandVals, FWK_MAGIC, send_command
 
 B1_WIDTH = 300
 B1_HEIGHT = 400

--- a/is_matrix_forge/inputmodule/c1minimal.py
+++ b/is_matrix_forge/inputmodule/c1minimal.py
@@ -1,4 +1,4 @@
-from inputmodule.inputmodule import send_command, CommandVals
+from . import CommandVals, send_command
 
 RGB_COLORS = ["white", "black", "red", "green",
               "blue", "cyan", "yellow", "purple"]

--- a/is_matrix_forge/inputmodule/ledmatrix.py
+++ b/is_matrix_forge/inputmodule/ledmatrix.py
@@ -4,6 +4,13 @@ import serial
 
 from . import font
 from . import send_command, CommandVals, PatternVals, FWK_MAGIC, send_serial, brightness
+from is_matrix_forge.led_matrix.display.helpers import light_leds, render_matrix
+from is_matrix_forge.led_matrix.hardware import (
+    animate as _hw_animate,
+    get_animate,
+    percentage,
+    pwm_freq,
+)
 
 from is_matrix_forge.led_matrix.helpers.status_handler import get_status, set_status
 
@@ -40,24 +47,11 @@ PWM_FREQUENCIES = [
 ]
 
 
-def percentage(dev, p):
-    """Fill a percentage of the screen. Bottom to top"""
-    send_command(dev, CommandVals.Pattern, [PatternVals.Percentage, p])
-
-
 def animate(dev, b: bool):
-    """Tell the firmware to start/stop animation.
-    Scrolls the currently saved grid vertically down."""
+    """Tell the firmware to start/stop animation and update local status tracking."""
     if b:
         set_status('animate')
-    send_command(dev, CommandVals.Animate, [b])
-
-
-def get_animate(dev):
-    """Tell the firmware to start/stop animation.
-    Scrolls the currently saved grid vertically down."""
-    res = send_command(dev, CommandVals.Animate, with_response=True)
-    return bool(res[0])
+    _hw_animate(dev, b)
 
 
 def image_bl(dev, image_file):
@@ -267,72 +261,6 @@ def eq(dev, vals):
             matrix[col][row - 1 - i] = 0xFF
 
     render_matrix(dev, matrix)
-
-
-def render_matrix(dev, matrix):
-    """Show a black/white matrix
-    Send everything in a single command"""
-    # Initialize a byte array to hold the binary representation of the matrix
-    # 39 bytes = 312 bits, which is enough for 9x34 = 306 pixels
-    vals = [0x00 for _ in range(39)]
-
-    # Iterate through each position in the 9x34 matrix
-    for x in range(9):
-        for y in range(34):
-            # Convert 2D coordinates to a linear index
-            # The matrix is stored in column-major order (y changes faster than x)
-            i = x + 9 * y
-
-            # If the pixel at this position is "on" (non-zero)
-            if matrix[x][y]:
-                # Calculate which byte in the vals array this pixel belongs to
-                byte_index = int(i / 8)
-
-                # Calculate which bit within that byte represents this pixel
-                bit_position = i % 8
-
-                # Set the corresponding bit in the appropriate byte
-                # This efficiently packs 8 pixels into each byte
-                vals[byte_index] = vals[byte_index] | (1 << bit_position)
-
-    # Send the packed binary data to the device
-    send_command(dev, CommandVals.Draw, vals)
-
-
-def light_leds(dev, leds):
-    """Light a specific number of LEDs"""
-    # Initialize a byte array with all LEDs off
-    vals = [0x00 for _ in range(39)]
-
-    # Calculate how many complete bytes we need to fill (each byte = 8 LEDs)
-    complete_bytes = int(leds / 8)
-
-    # Set all complete bytes to 0xFF (all 8 bits on)
-    for byte in range(complete_bytes):
-        vals[byte] = 0xFF
-
-    # Handle the remaining LEDs (less than 8) in the last partial byte
-    remaining_leds = leds % 8
-
-    # For each remaining LED, set the corresponding bit in the last byte
-    # This creates a binary pattern like 00011111 for 5 remaining LEDs
-    for i in range(remaining_leds):
-        vals[complete_bytes] += 1 << i
-
-    # Send the command to the device to display the pattern
-    send_command(dev, CommandVals.Draw, vals)
-
-
-def pwm_freq(dev, freq):
-    """Display a pattern that's already programmed into the firmware"""
-    if freq == "29kHz":
-        send_command(dev, CommandVals.PwmFreq, [0])
-    elif freq == "3.6kHz":
-        send_command(dev, CommandVals.PwmFreq, [1])
-    elif freq == "1.8kHz":
-        send_command(dev, CommandVals.PwmFreq, [2])
-    elif freq == "900Hz":
-        send_command(dev, CommandVals.PwmFreq, [3])
 
 
 def pattern(dev, p):

--- a/is_matrix_forge/led_matrix/display/grid/composite/__init__.py
+++ b/is_matrix_forge/led_matrix/display/grid/composite/__init__.py
@@ -1,10 +1,7 @@
 from .background import BackgroundGrid
 from .foreground import ForegroundGrid
-from .utils import (
-    PercentDisplayScene,
-    load_grid,
-    transpose as transpose_grid
-)
+from .utils import PercentDisplayScene
+from .helpers import load_grid, transpose as transpose_grid
 from .base import CompositeGrid
 
 

--- a/is_matrix_forge/led_matrix/display/grid/composite/base.py
+++ b/is_matrix_forge/led_matrix/display/grid/composite/base.py
@@ -3,7 +3,7 @@ from typing import Union, List
 from inspyre_toolbox.syntactic_sweets.classes import validate_type
 from is_matrix_forge.led_matrix.display.grid import Grid
 
-from .utils import load_grid, transpose
+from .helpers import load_grid, transpose
 
 
 class CompositeGrid(Grid):

--- a/is_matrix_forge/led_matrix/display/grid/composite/helpers.py
+++ b/is_matrix_forge/led_matrix/display/grid/composite/helpers.py
@@ -1,0 +1,41 @@
+"""Helper utilities for composite grid operations.
+
+This module contains small, dependency-free helpers that are shared between
+``CompositeGrid`` and the surrounding utility helpers.  Keeping these
+functions in their own module prevents circular-import issues between
+``base`` and ``utils``.
+"""
+
+from __future__ import annotations
+
+from typing import List, Union
+
+from is_matrix_forge.led_matrix.display.grid import Grid
+
+__all__ = ["load_grid", "transpose"]
+
+
+def transpose(grid: List[List[int]]) -> List[List[int]]:
+    """Transpose a two-dimensional list."""
+
+    return [list(col) for col in zip(*grid)]
+
+
+def load_grid(grid_like: Union[Grid, List[List[int]]]) -> Grid:
+    """Normalize *grid_like* into a :class:`~Grid` instance."""
+
+    if isinstance(grid_like, Grid):
+        return grid_like
+
+    if not isinstance(grid_like, list):
+        raise ValueError(
+            f"grid_like must be a list of lists or a Grid, not {type(grid_like)}"
+        )
+
+    try:
+        return Grid(init_grid=grid_like)
+    except ValueError as exc:
+        if str(exc).startswith("ValueError: init_grid must be"):
+            # Auto-transpose invalid grids to preserve legacy behaviour.
+            return Grid(init_grid=transpose(grid_like))
+        raise

--- a/is_matrix_forge/led_matrix/display/grid/composite/utils.py
+++ b/is_matrix_forge/led_matrix/display/grid/composite/utils.py
@@ -2,6 +2,7 @@ from typing import Optional, List, Union
 
 from is_matrix_forge.led_matrix.display.grid import Grid
 from .base import CompositeGrid
+from .helpers import load_grid, transpose
 from is_matrix_forge.led_matrix.display.grid.composite import BackgroundGrid, ForegroundGrid
 from inspyre_toolbox.syntactic_sweets.classes.decorators.type_validation import validate_type
 from is_matrix_forge.led_matrix.controller.controller import LEDMatrixController
@@ -293,22 +294,4 @@ class PercentDisplayScene(Loggable):
         self.draw(controller)
 
 
-def transpose(grid: List[List[int]]) -> List[List[int]]:
-    """Transpose a 2D list (rows <-> columns)."""
-    return [list(col) for col in zip(*grid)]
-
-
-def load_grid(grid_like: Union[Grid, List[List[int]]]) -> Grid:
-    """Normalize a grid-like object into a Grid instance."""
-    if isinstance(grid_like, Grid):
-        return grid_like
-    if not isinstance(grid_like, list):
-        raise ValueError(f'grid_like must be a list of lists or a Grid, not {type(grid_like)}')
-
-    try:
-        return Grid(init_grid=grid_like)
-    except ValueError as e:
-        if str(e).startswith('ValueError: init_grid must be'):
-            print('Auto-transposing invalid grid...')
-            return Grid(init_grid=transpose(grid_like))
-        raise
+__all__ = ["load_grid", "transpose", "PercentDisplayScene"]

--- a/is_matrix_forge/led_matrix/hardware.py
+++ b/is_matrix_forge/led_matrix/hardware.py
@@ -11,6 +11,7 @@ import serial
 from serial.tools.list_ports_common import ListPortInfo
 
 from is_matrix_forge.led_matrix.commands.map import CommandVals
+from is_matrix_forge.led_matrix.display.patterns.built_in.stencils.res import PatternVals
 
 from is_matrix_forge.led_matrix.constants import RESPONSE_SIZE, FWK_MAGIC, WIDTH, HEIGHT
 from is_matrix_forge.led_matrix.helpers import disconnect_dev, DISCONNECTED_DEVS
@@ -189,7 +190,6 @@ def get_animate(dev):
 
 def percentage(dev, p):
     """Fill a percentage of the screen from bottom to top."""
-    from is_matrix_forge.inputmodule import PatternVals
 
     send_command(dev, CommandVals.Pattern, [PatternVals.Percentage, p])
 


### PR DESCRIPTION
## Summary
- move composite grid helper functions into a dedicated helpers module to avoid circular imports
- update composite and hardware modules to import helpers directly
- replace duplicated inputmodule definitions with re-exports from canonical LED matrix modules and fix relative imports

## Testing
- pytest *(fails: command not found)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690e27dae754832dbe7d3e807db7e6fc)

## Summary by Sourcery

Deduplicate inputmodule by re-exporting constants, enums, and functions from core LED matrix modules and move composite grid helper functions into a dedicated helpers module to resolve circular import issues and streamline imports across the codebase.

Enhancements:
- Refactor inputmodule/__init__.py to remove duplicated definitions and re-export commands, constants, and helpers from canonical led_matrix modules
- Relocate composite grid helper functions (load_grid, transpose) into a new composite/helpers.py module and update imports in base and utils files

Chores:
- Update relative imports in inputmodule b1display and c1minimal to use the simplified __init__.py exports