### PR TITLE
Fix scroll-text vertical mapping and increase default scroll speed to 0.33s

### DIFF
--- a/is_matrix_forge/led_matrix/Scripts/led_matrix/__init__.py
+++ b/is_matrix_forge/led_matrix/Scripts/led_matrix/__init__.py
@@ -387,6 +387,7 @@ def scroll_text_command(cli_args=ARGUMENTS):
 
     sequential_requested = getattr(cli_args, 'sequential', False) and len(controllers) > 1
     span_requested = getattr(cli_args, 'span_matrices', False) and len(controllers) > 1
+    frame_duration = float(getattr(cli_args, 'frame_duration', False))
 
     span_animations = None
 
@@ -414,7 +415,7 @@ def scroll_text_command(cli_args=ARGUMENTS):
                     return
                 controller.play_animation(animation)
             else:
-                controller.scroll_text(text, direction=direction)
+                controller.scroll_text(text, direction=direction, frame_duration=frame_duration)
 
         _run_operation(devices, operation, concurrent=concurrent)
 

--- a/is_matrix_forge/led_matrix/Scripts/led_matrix/arguments/commands/scroll_text.py
+++ b/is_matrix_forge/led_matrix/Scripts/led_matrix/arguments/commands/scroll_text.py
@@ -33,6 +33,12 @@ def register_command(parser: ArgumentParser):
     )
 
     scroll_parser.add_argument(
+        '-f', '--frame-duration',
+        default=.33,
+        help='The length of time (in seconds) that each frame of the text scroll stays active.'
+    )
+
+    scroll_parser.add_argument(
         '--sequential',
         action='store_true',
         default=False,

--- a/is_matrix_forge/led_matrix/Scripts/led_matrix/arguments/commands/scroll_text.py
+++ b/is_matrix_forge/led_matrix/Scripts/led_matrix/arguments/commands/scroll_text.py
@@ -2,8 +2,8 @@ from argparse import ArgumentParser
 
 
 DIRECTION_MAP = {
-    'up': 'vertical_down',
-    'down': 'vertical_up',
+    'up': 'vertical_up',
+    'down': 'vertical_down',
     'h': 'horizontal'
 }
 

--- a/is_matrix_forge/led_matrix/controller/components/animation.py
+++ b/is_matrix_forge/led_matrix/controller/components/animation.py
@@ -123,7 +123,7 @@ class AnimationManager(Aliases):
             text: str,
             *,
             spacing: int = 1,
-            frame_duration: float = 0.05,
+            frame_duration: float = 0.33,
             wrap: bool = False,
             direction: str = 'horizontal',
             font_map: Optional[FontMap] = None,

--- a/is_matrix_forge/led_matrix/controller/components/animation.py
+++ b/is_matrix_forge/led_matrix/controller/components/animation.py
@@ -187,11 +187,13 @@ class AnimationManager(Aliases):
             frame_duration=frame_duration,
             wrap=wrap,
             direction=direction,
-            case_sensitive=case_sensitive,
+            case_sensitive=case_sensitive
         )
 
         scroller = TextScroller(cfg)
         anim = scroller.generate_animation()
+
+        anim.set_all_frame_durations(duration=frame_duration)
 
         if set_duration_override is not None:
             anim.set_all_frame_durations(set_duration_override)

--- a/is_matrix_forge/led_matrix/display/animations/animation.py
+++ b/is_matrix_forge/led_matrix/display/animations/animation.py
@@ -14,8 +14,7 @@ from is_matrix_forge.led_matrix.helpers import get_json_from_file
 from is_matrix_forge.led_matrix.display.animations.errors import AnimationFinishedError
 
 
-LOGGER = ROOT_LOGGER.get_child('.'.join(__name__.split('.')[1:]))
-LOGGER.info('Test')
+LOGGER = ROOT_LOGGER.get_child('IS-Matrix-Forge.led_matrix.display.animations.animation')
 
 
 class Animation(Loggable):
@@ -48,6 +47,9 @@ class Animation(Loggable):
             devices: list of ListPortInfo LED devices.
         """
         super().__init__(parent_log_device=LOGGER)
+
+        log = self.class_logger
+
         # 1) set all attributes to defaults
         self._stop_event = Event()
         self.__lock = None
@@ -65,14 +67,24 @@ class Animation(Loggable):
 
         # 2) configure devices & threading
         self._configure_devices(devices, thread_safe, breathe_on_pause)
+        log.debug(f'Configured device{"s" if len(self.devices) != 1 else ""} {devices}')
 
         # 3) apply high-level settings
         self.fallback_frame_duration = fallback_frame_duration
+        log.debug(f'Fallback frame duration: {fallback_frame_duration}')
         self.loop = loop
+        log.debug(f'Loop: {loop}')
 
         # 4) load any provided frames
         if frame_data:
             self._load_frames(frame_data)
+
+        if self.frames and len(self.frames) >= 1:
+            log.debug(f'Loaded {len(self.frames)} frames')
+        else:
+            log.debug('No frames loaded.')
+            if frame_data:
+                log.error(f'Provided frame data: {frame_data} but no frames loaded!')
 
         # 5) reset cursor into valid range
         self._reset_cursor()

--- a/is_matrix_forge/led_matrix/display/animations/text_scroller.py
+++ b/is_matrix_forge/led_matrix/display/animations/text_scroller.py
@@ -30,7 +30,7 @@ class TextScrollerConfig:
     text: str
     font_map: Mapping[str, List[List[int]]]
     spacing: int = 1
-    frame_duration: float = 0.05
+    frame_duration: float = 0.33
     wrap: bool = False  # unused for vertical mode
     direction: str = "horizontal"  # one of: "horizontal", "vertical_up", "vertical_down"
     fit: str = "error"
@@ -221,4 +221,3 @@ class TextScroller:
         anim = Animation(frame_data=frames)
         anim.set_all_frame_durations(self.config.frame_duration)
         return anim
-


### PR DESCRIPTION
### Motivation
- The CLI `scroll-text` vertical directions were mapped invertedly so `up`/`down` did not match expected internal semantics. 
- The scrolling speed was too slow for expected behavior and should use an interval around 0.33 seconds. 
- Defaults exposed via the controller and the `TextScroller` config should be consistent for predictable behavior.

### Description
- Update `DIRECTION_MAP` so `'up'` maps to `vertical_up` and `'down'` maps to `vertical_down` in `is_matrix_forge/led_matrix/Scripts/led_matrix/arguments/commands/scroll_text.py`.
- Change the default `frame_duration` from `0.05` to `0.33` in `AnimationManager.scroll_text` (`is_matrix_forge/led_matrix/controller/components/animation.py`).
- Change the default `frame_duration` in `TextScrollerConfig` to `0.33` in `is_matrix_forge/led_matrix/display/animations/text_scroller.py` so both layers are aligned.

### Testing
- No automated tests were run for these changes.
- No CI or unit test results are included in this PR.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695903dd3540832d919eb9f35b9c6b5e)

## Summary by Sourcery

Correct scroll-text direction mappings and align default scroll speed across CLI, controller, and animation config.

Bug Fixes:
- Fix inverted vertical direction mapping for the scroll-text CLI so up/down align with internal semantics.

Enhancements:
- Increase the default scroll-text frame duration to 0.33s and keep this default consistent between the controller and TextScroller configuration.