### PR TITLE
Add CLI version, debug, and ticket-info support

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -6,6 +6,9 @@ body:
     attributes:
       value: |
         Thanks for taking the time to report a bug! Please fill out the fields below so we can reproduce and fix the issue.
+        
+        If you can run the CLI, please attach the output of `led-matrix ticket-info`
+        or paste the Markdown version from `led-matrix ticket-info --copy --copy-format markdown`.
 
   - type: textarea
     id: description

--- a/README.md
+++ b/README.md
@@ -10,10 +10,9 @@ hardware, tools for building animations, and utilities such as progress bars.
 
 ## Project Overview
 
-Matrix Forge grew out of the LED Matrix project.  The goal is to
-make it easy to create rich LED matrix experiences from Python.  You can design
-custom frames, display scrolling text, run animations, and integrate the LED
-matrix with your own applications.
+Matrix Forge is focused on making it easy to create rich LED matrix
+experiences from Python. You can design custom frames, display scrolling text,
+run animations, and integrate the LED matrix with your own applications.
 
 Highlighted features include:
 - Device discovery and control via `pyserial`

--- a/is_matrix_forge/led_matrix/Scripts/led_matrix/__init__.py
+++ b/is_matrix_forge/led_matrix/Scripts/led_matrix/__init__.py
@@ -441,12 +441,62 @@ def bootloader_command(cli_args):
         cli_args: argparse.Namespace
             The parsed arguments for the ``bootloader`` sub-command.
     """
-    controllers = execute_get_controllers(cli_args)
+    from is_matrix_forge.led_matrix.Scripts.led_matrix.support import get_selected_devices
+    from is_matrix_forge.led_matrix.console import info
+    from is_matrix_forge.led_matrix.hardware import bootloader_jump
 
-    for controller in controllers:
-        from is_matrix_forge.led_matrix.console import info
-        info(f'Entering bootloader on [bold]{controller!r}[/bold] …')
-        controller.jump_to_bootloader()
+    devices = get_selected_devices(cli_args)
+
+    for device in devices:
+        info(f"Entering bootloader on [bold]{getattr(device, 'name', device)!r}[/bold] …")
+        bootloader_jump(device)
+
+
+def controller_info_command(cli_args):
+    """Print detailed controller/device information for debugging."""
+    from is_matrix_forge.led_matrix.Scripts.led_matrix.support import (
+        build_controller_info_report,
+        get_selected_devices,
+    )
+    from is_matrix_forge.led_matrix.console import CONSOLE
+
+    devices = get_selected_devices(cli_args)
+    report = build_controller_info_report(
+        devices,
+        include_firmware=not getattr(cli_args, "no_firmware", False),
+    )
+    CONSOLE.print(report, markup=False)
+
+
+def ticket_info_command(cli_args):
+    """Generate a support-friendly report for issue filing."""
+    from is_matrix_forge.led_matrix.Scripts.led_matrix.support import (
+        build_ticket_info_report,
+        copy_text_to_clipboard,
+    )
+    from is_matrix_forge.led_matrix.console import CONSOLE, success, warning
+
+    report = build_ticket_info_report(
+        cli_args,
+        include_update_check=not getattr(cli_args, "no_update_check", False),
+        include_firmware=not getattr(cli_args, "no_firmware", False),
+    )
+    CONSOLE.print(report, markup=False)
+
+    if getattr(cli_args, "copy", False):
+        copy_report = build_ticket_info_report(
+            cli_args,
+            include_update_check=not getattr(cli_args, "no_update_check", False),
+            include_firmware=not getattr(cli_args, "no_firmware", False),
+            format=getattr(cli_args, "copy_format", "plain"),
+        )
+        copied, backend = copy_text_to_clipboard(copy_report)
+        if copied:
+            success(
+                f"Ticket info copied to the clipboard as {getattr(cli_args, 'copy_format', 'plain')} text via {backend}."
+            )
+        else:
+            warning(f"Could not copy ticket info automatically. {backend}")
 
 
 def install_presets_command(cli_args):
@@ -667,6 +717,8 @@ def main(cli_args=ARGUMENTS):
         ('scroll_until_parser',       'Scroll-until command parser was not initialized.',         scroll_until_command),
         ('set_presets_dir_parser',    'Set-presets-dir command parser was not initialized.',      set_presets_dir_command),
         ('show_presets_dir_parser',   'Show-presets-dir command parser was not initialized.',     show_presets_dir_command),
+        ('controller_info_parser',    'Controller-info command parser was not initialized.',      controller_info_command),
+        ('ticket_info_parser',        'Ticket-info command parser was not initialized.',          ticket_info_command),
     )
 
     for attr_name, error_message, handler in parser_bindings:

--- a/is_matrix_forge/led_matrix/Scripts/led_matrix/arguments/__init__.py
+++ b/is_matrix_forge/led_matrix/Scripts/led_matrix/arguments/__init__.py
@@ -1,6 +1,32 @@
-from argparse import ArgumentParser
+from argparse import Action, ArgumentParser
 from is_matrix_forge.log_engine import LOG_LEVELS
 from is_matrix_forge.led_matrix.constants import APP_DIRS
+
+
+def build_version_output(*, check_updates: bool = False) -> str:
+    from is_matrix_forge.led_matrix.Scripts.led_matrix.support import build_version_output as _build_version_output
+
+    return _build_version_output(check_updates=check_updates)
+
+
+class _VersionAction(Action):
+    def __init__(self, option_strings, dest, **kwargs):
+        kwargs.setdefault("nargs", 0)
+        super().__init__(option_strings, dest, **kwargs)
+
+    def __call__(self, parser, namespace, values, option_string=None):
+        print(build_version_output(check_updates=False))
+        parser.exit()
+
+
+class _CheckUpdatesAction(Action):
+    def __init__(self, option_strings, dest, **kwargs):
+        kwargs.setdefault("nargs", 0)
+        super().__init__(option_strings, dest, **kwargs)
+
+    def __call__(self, parser, namespace, values, option_string=None):
+        print(build_version_output(check_updates=True))
+        parser.exit()
 
 
 class Arguments(ArgumentParser):
@@ -25,6 +51,19 @@ class Arguments(ArgumentParser):
         self.__scroll_until_parser    = None
         self.__set_presets_dir_parser = None
         self.__show_presets_dir_parser = None
+        self.__controller_info_parser = None
+        self.__ticket_info_parser = None
+
+        self.add_argument(
+            "-V", "--version",
+            action=_VersionAction,
+            help="Show the installed/source version information and exit.",
+        )
+        self.add_argument(
+            "--check-updates",
+            action=_CheckUpdatesAction,
+            help="Check PyPI for a newer release and exit.",
+        )
 
         selection_group = self.add_mutually_exclusive_group()
         selection_group.add_argument(
@@ -99,6 +138,14 @@ class Arguments(ArgumentParser):
     def show_presets_dir_parser(self):
         return self.__show_presets_dir_parser
 
+    @property
+    def controller_info_parser(self):
+        return self.__controller_info_parser
+
+    @property
+    def ticket_info_parser(self):
+        return self.__ticket_info_parser
+
     def __build_identify_matrices(self):
         from .commands.identify_matrices import register_command
         self.__identify_parser = register_command(self)
@@ -131,6 +178,14 @@ class Arguments(ArgumentParser):
         from .commands.show_presets_dir import register_command
         self.__show_presets_dir_parser = register_command(self)
 
+    def __build_controller_info(self):
+        from .commands.controller_info import register_command
+        self.__controller_info_parser = register_command(self)
+
+    def __build_ticket_info(self):
+        from .commands.ticket_info import register_command
+        self.__ticket_info_parser = register_command(self)
+
     def __build(self):
         self.__building = True
 
@@ -142,6 +197,8 @@ class Arguments(ArgumentParser):
         self.__build_scroll_until()
         self.__build_set_presets_dir()
         self.__build_show_presets_dir()
+        self.__build_controller_info()
+        self.__build_ticket_info()
 
         self.__building = False
         self.__built    = True

--- a/is_matrix_forge/led_matrix/Scripts/led_matrix/arguments/commands/controller_info.py
+++ b/is_matrix_forge/led_matrix/Scripts/led_matrix/arguments/commands/controller_info.py
@@ -1,0 +1,28 @@
+from argparse import ArgumentParser
+
+from . import add_matrix_selection_args
+
+
+COMMAND = "controller-info"
+
+HELP_TXT = (
+    "Show detected matrix/controller details, including serial metadata and "
+    "firmware version when available."
+)
+
+
+def register_command(parser: ArgumentParser):
+    info_parser = parser.SUBCOMMANDS.add_parser(
+        COMMAND,
+        help=HELP_TXT,
+    )
+
+    add_matrix_selection_args(info_parser)
+    info_parser.add_argument(
+        "--no-firmware",
+        action="store_true",
+        default=False,
+        help="Skip the live firmware version query.",
+    )
+
+    return info_parser

--- a/is_matrix_forge/led_matrix/Scripts/led_matrix/arguments/commands/ticket_info.py
+++ b/is_matrix_forge/led_matrix/Scripts/led_matrix/arguments/commands/ticket_info.py
@@ -1,0 +1,46 @@
+from argparse import ArgumentParser
+
+from . import add_matrix_selection_args
+
+
+COMMAND = "ticket-info"
+
+HELP_TXT = (
+    "Print a support-friendly report for filing a bug ticket, with an option "
+    "to copy the full report to the clipboard."
+)
+
+
+def register_command(parser: ArgumentParser):
+    ticket_parser = parser.SUBCOMMANDS.add_parser(
+        COMMAND,
+        help=HELP_TXT,
+    )
+
+    add_matrix_selection_args(ticket_parser)
+    ticket_parser.add_argument(
+        "--copy",
+        action="store_true",
+        default=False,
+        help="Copy the generated ticket report to the clipboard when possible.",
+    )
+    ticket_parser.add_argument(
+        "--copy-format",
+        choices=("plain", "markdown"),
+        default="plain",
+        help="Choose whether copied ticket info should use plaintext or Markdown formatting.",
+    )
+    ticket_parser.add_argument(
+        "--no-firmware",
+        action="store_true",
+        default=False,
+        help="Skip the live firmware version query.",
+    )
+    ticket_parser.add_argument(
+        "--no-update-check",
+        action="store_true",
+        default=False,
+        help="Skip the bounded PyPI update check.",
+    )
+
+    return ticket_parser

--- a/is_matrix_forge/led_matrix/Scripts/led_matrix/support.py
+++ b/is_matrix_forge/led_matrix/Scripts/led_matrix/support.py
@@ -8,6 +8,8 @@ from datetime import datetime
 from pathlib import Path
 from typing import Iterable, Optional
 
+from packaging.version import InvalidVersion, Version
+
 from is_matrix_forge.led_matrix.hardware import get_version as get_firmware_version
 from is_matrix_forge.led_matrix.helpers.device import get_devices
 from is_matrix_forge.led_matrix.helpers.location import resolve_device_location
@@ -149,6 +151,26 @@ def _query_firmware_version(device) -> str:
         return f"Unavailable ({type(exc).__name__}: {exc})"
 
 
+def _parse_version(version_text: Optional[str]) -> Optional[Version]:
+    if not version_text:
+        return None
+
+    try:
+        return Version(str(version_text).strip())
+    except (InvalidVersion, TypeError, ValueError):
+        return None
+
+
+def _is_newer_than_pypi(current_version: Optional[str], latest_version: Optional[str]) -> bool:
+    parsed_current = _parse_version(current_version)
+    parsed_latest = _parse_version(latest_version)
+
+    if parsed_current is None or parsed_latest is None:
+        return False
+
+    return parsed_current > parsed_latest
+
+
 def _build_device_fields(device, *, include_firmware: bool = True) -> list[tuple[str, str]]:
     resolved_location, raw_location = _format_location(device)
     fields = [
@@ -208,27 +230,44 @@ def safe_check_for_updates(*, timeout: float = 3.0) -> dict[str, Optional[str]]:
             info = PyPiVersionInfo("IS-Matrix-Forge", include_pre_release_for_update_check=True)
 
         latest = info.latest_pre_release or info.latest_stable or info.latest
+        latest_text = str(latest) if latest is not None else None
         installed = str(info.installed) if info.installed else None
+        snapshot = get_version_snapshot()
+        source_version = snapshot.get("source_version") or snapshot.get("display_version")
+        messages: list[str] = []
+        current_status = "up-to-date"
 
         if installed is None:
-            return {
-                "status": "unavailable",
-                "message": f"PyPI latest release: {latest} (installed distribution metadata unavailable for comparison).",
-                "latest": str(latest) if latest is not None else None,
-            }
-
-        if info.check_for_update():
+            messages.append(
+                f"PyPI latest release: {latest_text} (installed distribution metadata unavailable for comparison)."
+            )
+            current_status = "unavailable"
+        elif _is_newer_than_pypi(installed, latest_text):
+            messages.append(
+                f"Installed distribution version {installed} is newer than the latest PyPI release {latest_text}."
+            )
+            current_status = "local-newer-than-pypi"
+        elif info.check_for_update():
             newer_version = str(info.newer_available_version or latest)
-            return {
-                "status": "update-available",
-                "message": f"Update available on PyPI: {newer_version} (installed: {installed}).",
-                "latest": newer_version,
-            }
+            messages.append(f"Update available on PyPI: {newer_version} (installed: {installed}).")
+            current_status = "update-available"
+        else:
+            messages.append(f"Installed distribution matches the latest PyPI release ({latest_text}).")
+
+        if (
+            source_version
+            and source_version != installed
+            and _is_newer_than_pypi(source_version, latest_text)
+        ):
+            messages.append(
+                f"Current source tree version {source_version} is newer than the latest PyPI release {latest_text}."
+            )
+            current_status = "local-newer-than-pypi"
 
         return {
-            "status": "up-to-date",
-            "message": f"PyPI is up to date for the installed distribution (latest: {latest}).",
-            "latest": str(latest) if latest is not None else None,
+            "status": current_status,
+            "message": " ".join(messages),
+            "latest": latest_text,
         }
     except Exception as exc:
         return {

--- a/is_matrix_forge/led_matrix/Scripts/led_matrix/support.py
+++ b/is_matrix_forge/led_matrix/Scripts/led_matrix/support.py
@@ -237,12 +237,14 @@ def safe_check_for_updates(*, timeout: float = 3.0) -> dict[str, Optional[str]]:
         messages: list[str] = []
         current_status = "up-to-date"
 
+        installed_newer_than_latest = bool(getattr(info, "installed_newer_than_latest", False))
+
         if installed is None:
             messages.append(
                 f"PyPI latest release: {latest_text} (installed distribution metadata unavailable for comparison)."
             )
             current_status = "unavailable"
-        elif _is_newer_than_pypi(installed, latest_text):
+        elif installed_newer_than_latest or _is_newer_than_pypi(installed, latest_text):
             messages.append(
                 f"Installed distribution version {installed} is newer than the latest PyPI release {latest_text}."
             )

--- a/is_matrix_forge/led_matrix/Scripts/led_matrix/support.py
+++ b/is_matrix_forge/led_matrix/Scripts/led_matrix/support.py
@@ -1,0 +1,409 @@
+from __future__ import annotations
+
+import contextlib
+import platform
+import subprocess
+import sys
+from datetime import datetime
+from pathlib import Path
+from typing import Iterable, Optional
+
+from is_matrix_forge.led_matrix.hardware import get_version as get_firmware_version
+from is_matrix_forge.led_matrix.helpers.device import get_devices
+from is_matrix_forge.led_matrix.helpers.location import resolve_device_location
+from is_matrix_forge.version import get_version_snapshot
+
+
+def _safe_getattr(obj, attr: str, default=None):
+    try:
+        return getattr(obj, attr)
+    except Exception:
+        return default
+
+
+def _desired_side(cli_args) -> Optional[str]:
+    if cli_args is None:
+        return None
+    if getattr(cli_args, "only_left", False):
+        return "left"
+    if getattr(cli_args, "only_right", False):
+        return "right"
+    return None
+
+
+def describe_selection(cli_args) -> str:
+    desired = _desired_side(cli_args)
+    if desired == "left":
+        return "the leftmost LED matrix"
+    if desired == "right":
+        return "the rightmost LED matrix"
+    return "all detected LED matrices"
+
+
+def _device_side(device) -> Optional[str]:
+    location = resolve_device_location(device)
+    if isinstance(location, dict):
+        side = location.get("side")
+        if isinstance(side, str):
+            return side.strip().lower()
+    return None
+
+
+def _device_slot_rank(device) -> int:
+    location = resolve_device_location(device)
+    if isinstance(location, dict):
+        try:
+            return int(location.get("slot"))
+        except (TypeError, ValueError):
+            return 0
+    return 0
+
+
+def find_leftmost_device(devices: Iterable) -> Optional[object]:
+    ranked = []
+    for index, device in enumerate(devices):
+        side = _device_side(device)
+        if side == "left":
+            side_rank = 0
+        elif side == "right":
+            side_rank = 2
+        else:
+            side_rank = 1
+        ranked.append(((side_rank, _device_slot_rank(device), index), device))
+
+    if not ranked:
+        return None
+    return min(ranked, key=lambda item: item[0])[1]
+
+
+def find_rightmost_device(devices: Iterable) -> Optional[object]:
+    ranked = []
+    for index, device in enumerate(devices):
+        side = _device_side(device)
+        if side == "right":
+            side_rank = 0
+        elif side == "left":
+            side_rank = 2
+        else:
+            side_rank = 1
+        ranked.append(((side_rank, -_device_slot_rank(device), index), device))
+
+    if not ranked:
+        return None
+    return min(ranked, key=lambda item: item[0])[1]
+
+
+def filter_devices_by_side(devices: Iterable, cli_args) -> list:
+    device_list = list(devices)
+    desired = _desired_side(cli_args)
+
+    if desired is None:
+        return device_list
+
+    if desired == "left":
+        target = find_leftmost_device(device_list)
+        return [target] if target is not None else []
+
+    if desired == "right":
+        target = find_rightmost_device(device_list)
+        return [target] if target is not None else []
+
+    return device_list
+
+
+def get_selected_devices(cli_args=None) -> list:
+    devices = get_devices()
+    if not devices:
+        raise SystemExit("No LED matrices are available.")
+
+    if filtered := filter_devices_by_side(devices, cli_args):
+        return filtered
+
+    raise SystemExit(f"No LED matrices matched the requested selection ({describe_selection(cli_args)}).")
+
+
+def _format_hex(value) -> str:
+    if isinstance(value, int):
+        return f"0x{value:04X}"
+    return "Unknown"
+
+
+def _format_location(device) -> tuple[str, str]:
+    resolved = resolve_device_location(device)
+    raw_location = str(_safe_getattr(device, "location", "Unknown"))
+
+    if not isinstance(resolved, dict):
+        return "Unknown", raw_location
+
+    abbrev = resolved.get("abbrev") or "Unknown"
+    side = resolved.get("side") or "unknown"
+    slot = resolved.get("slot")
+    slot_text = f" slot {slot}" if slot is not None else ""
+    return f"{abbrev} ({side}{slot_text})", raw_location
+
+
+def _query_firmware_version(device) -> str:
+    try:
+        return str(get_firmware_version(device))
+    except Exception as exc:
+        return f"Unavailable ({type(exc).__name__}: {exc})"
+
+
+def _build_device_fields(device, *, include_firmware: bool = True) -> list[tuple[str, str]]:
+    resolved_location, raw_location = _format_location(device)
+    fields = [
+        ("name", str(_safe_getattr(device, "name", "Unknown"))),
+        ("serial_port", str(_safe_getattr(device, "device", "Unknown"))),
+        ("description", str(_safe_getattr(device, "description", "Unknown"))),
+        ("serial_number", str(_safe_getattr(device, "serial_number", "Unknown"))),
+        ("location", resolved_location),
+        ("raw_location", raw_location),
+        ("manufacturer", str(_safe_getattr(device, "manufacturer", "Unknown"))),
+        ("product", str(_safe_getattr(device, "product", "Unknown"))),
+        ("hwid", str(_safe_getattr(device, "hwid", "Unknown"))),
+        ("vid", _format_hex(_safe_getattr(device, "vid"))),
+        ("pid", _format_hex(_safe_getattr(device, "pid"))),
+    ]
+
+    if include_firmware:
+        fields.append(("firmware_version", _query_firmware_version(device)))
+
+    return fields
+
+
+def build_controller_info_report(devices: Iterable, *, include_firmware: bool = True) -> str:
+    device_list = list(devices)
+    lines = [f"Detected matrices: {len(device_list)}"]
+
+    for index, device in enumerate(device_list, start=1):
+        lines.extend(["", f"Matrix {index}:"])
+        for key, value in _build_device_fields(device, include_firmware=include_firmware):
+            lines.append(f"  {key}: {value}")
+
+    return "\n".join(lines)
+
+
+@contextlib.contextmanager
+def _pypi_request_timeout(timeout: float):
+    from inspyre_toolbox.ver_man.classes import pypi as pypi_module
+
+    original_get = pypi_module.requests.get
+
+    def _timed_get(*args, **kwargs):
+        kwargs.setdefault("timeout", timeout)
+        return original_get(*args, **kwargs)
+
+    pypi_module.requests.get = _timed_get
+    try:
+        yield
+    finally:
+        pypi_module.requests.get = original_get
+
+
+def safe_check_for_updates(*, timeout: float = 3.0) -> dict[str, Optional[str]]:
+    try:
+        from inspyre_toolbox.ver_man import PyPiVersionInfo
+
+        with _pypi_request_timeout(timeout):
+            info = PyPiVersionInfo("IS-Matrix-Forge", include_pre_release_for_update_check=True)
+
+        latest = info.latest_pre_release or info.latest_stable or info.latest
+        installed = str(info.installed) if info.installed else None
+
+        if installed is None:
+            return {
+                "status": "unavailable",
+                "message": f"PyPI latest release: {latest} (installed distribution metadata unavailable for comparison).",
+                "latest": str(latest) if latest is not None else None,
+            }
+
+        if info.check_for_update():
+            newer_version = str(info.newer_available_version or latest)
+            return {
+                "status": "update-available",
+                "message": f"Update available on PyPI: {newer_version} (installed: {installed}).",
+                "latest": newer_version,
+            }
+
+        return {
+            "status": "up-to-date",
+            "message": f"PyPI is up to date for the installed distribution (latest: {latest}).",
+            "latest": str(latest) if latest is not None else None,
+        }
+    except Exception as exc:
+        return {
+            "status": "unavailable",
+            "message": f"PyPI update check unavailable ({type(exc).__name__}: {exc}).",
+            "latest": None,
+        }
+
+
+def build_version_output(*, check_updates: bool = False) -> str:
+    snapshot = get_version_snapshot()
+    lines = [f"{snapshot['package_name']} {snapshot['display_version']}"]
+
+    source_version = snapshot.get("source_version")
+    installed_version = snapshot.get("installed_version")
+
+    if source_version and installed_version and source_version != installed_version:
+        lines.append(f"Source tree version: {source_version}")
+        lines.append(f"Installed distribution version: {installed_version}")
+    elif installed_version and installed_version != snapshot["display_version"]:
+        lines.append(f"Installed distribution version: {installed_version}")
+
+    if check_updates:
+        lines.append(safe_check_for_updates()["message"])
+    else:
+        lines.append("Run `led-matrix --check-updates` to compare against PyPI.")
+
+    return "\n".join(lines)
+
+
+def _collect_ticket_info(
+    cli_args=None,
+    *,
+    include_update_check: bool = True,
+    include_firmware: bool = True,
+) -> dict[str, object]:
+    snapshot = get_version_snapshot()
+    selected_devices = filter_devices_by_side(get_devices(), cli_args)
+    metadata = [
+        ("Generated", datetime.now().astimezone().isoformat(timespec="seconds")),
+        ("Version", snapshot["display_version"]),
+        ("Source tree version", snapshot.get("source_version") or "Unavailable"),
+        ("Installed distribution version", snapshot.get("installed_version") or "Unavailable"),
+        ("Python", platform.python_version()),
+        ("Python executable", sys.executable),
+        ("Platform", platform.platform()),
+        ("Machine", platform.machine() or "Unknown"),
+        ("Working directory", str(Path.cwd())),
+        ("Matrix selection", describe_selection(cli_args)),
+    ]
+
+    if include_update_check:
+        metadata.append(("Update check", safe_check_for_updates()["message"]))
+    else:
+        metadata.append(("Update check", "Skipped by user request."))
+
+    return {
+        "metadata": metadata,
+        "devices": list(selected_devices),
+        "include_firmware": include_firmware,
+    }
+
+
+def build_ticket_info_markdown_report(
+    cli_args=None,
+    *,
+    include_update_check: bool = True,
+    include_firmware: bool = True,
+) -> str:
+    report_data = _collect_ticket_info(
+        cli_args,
+        include_update_check=include_update_check,
+        include_firmware=include_firmware,
+    )
+    metadata = report_data["metadata"]
+    devices = report_data["devices"]
+
+    lines = ["# IS-Matrix-Forge Ticket Info", ""]
+    for key, value in metadata:
+        lines.append(f"- **{key}:** {value}")
+
+    lines.append("")
+    lines.append("## Matrices")
+    lines.append("")
+
+    if devices:
+        lines.append(f"- **Detected matrices:** {len(devices)}")
+        lines.append("")
+        for index, device in enumerate(devices, start=1):
+            lines.append(f"### Matrix {index}")
+            lines.append("")
+            for key, value in _build_device_fields(device, include_firmware=include_firmware):
+                lines.append(f"- **{key}:** {value}")
+            lines.append("")
+    else:
+        lines.append("- **Detected matrices:** 0")
+        lines.append("- No supported LED matrices matched the current selection.")
+
+    return "\n".join(lines).rstrip()
+
+
+def build_ticket_info_report(
+    cli_args=None,
+    *,
+    include_update_check: bool = True,
+    include_firmware: bool = True,
+    format: str = "plain",
+) -> str:
+    if format == "markdown":
+        return build_ticket_info_markdown_report(
+            cli_args,
+            include_update_check=include_update_check,
+            include_firmware=include_firmware,
+        )
+
+    if format != "plain":
+        raise ValueError(f"Unsupported ticket info format: {format!r}")
+
+    report_data = _collect_ticket_info(
+        cli_args,
+        include_update_check=include_update_check,
+        include_firmware=include_firmware,
+    )
+    metadata = report_data["metadata"]
+    devices = report_data["devices"]
+
+    lines = ["IS-Matrix-Forge Ticket Info"]
+    for key, value in metadata:
+        lines.append(f"{key}: {value}")
+
+    lines.append("")
+    if devices:
+        lines.append(build_controller_info_report(devices, include_firmware=include_firmware))
+    else:
+        lines.append("Detected matrices: 0")
+        lines.append("No supported LED matrices matched the current selection.")
+
+    return "\n".join(lines)
+
+
+def copy_text_to_clipboard(text: str) -> tuple[bool, str]:
+    try:
+        import clipboard as clipboard_module
+
+        clipboard_module.copy(text)
+        return True, "clipboard"
+    except Exception:
+        pass
+
+    try:
+        import tkinter as tk
+
+        root = tk.Tk()
+        root.withdraw()
+        root.clipboard_clear()
+        root.clipboard_append(text)
+        root.update()
+        root.destroy()
+        return True, "tkinter"
+    except Exception:
+        pass
+
+    commands = []
+    if sys.platform.startswith("win"):
+        commands.extend((["powershell", "-NoProfile", "-Command", "Set-Clipboard"], ["clip"]))
+    elif sys.platform == "darwin":
+        commands.append(["pbcopy"])
+    else:
+        commands.extend((["wl-copy"], ["xclip", "-selection", "clipboard"], ["xsel", "--clipboard", "--input"]))
+
+    for command in commands:
+        try:
+            subprocess.run(command, input=text, text=True, capture_output=True, check=True)
+            return True, " ".join(command)
+        except Exception:
+            continue
+
+    return False, "No clipboard backend is available in this environment."

--- a/is_matrix_forge/version.py
+++ b/is_matrix_forge/version.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+from importlib import metadata
+from pathlib import Path
+from typing import Optional
+
+import tomllib
+
+
+PACKAGE_NAME = "IS-Matrix-Forge"
+
+
+def get_project_root() -> Path:
+    return Path(__file__).resolve().parents[1]
+
+
+def get_source_version() -> Optional[str]:
+    pyproject_path = get_project_root() / "pyproject.toml"
+    if not pyproject_path.is_file():
+        return None
+
+    try:
+        with pyproject_path.open("rb") as handle:
+            data = tomllib.load(handle)
+    except OSError:
+        return None
+
+    return data.get("tool", {}).get("poetry", {}).get("version")
+
+
+def get_installed_version(package_name: str = PACKAGE_NAME) -> Optional[str]:
+    try:
+        return metadata.version(package_name)
+    except metadata.PackageNotFoundError:
+        return None
+
+
+def get_version_snapshot() -> dict[str, Optional[str]]:
+    source_version = get_source_version()
+    installed_version = get_installed_version()
+    display_version = source_version or installed_version or "unknown"
+
+    return {
+        "package_name": PACKAGE_NAME,
+        "display_version": display_version,
+        "source_version": source_version,
+        "installed_version": installed_version,
+    }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "IS-Matrix-Forge"
-version = "1.0.0-dev.29"
+version = "1.0.0-dev.30"
 
 description = ""
 authors = ["Taylor B. <t.blackstone@inspyre.tech>"]

--- a/tests/test_cli_args.py
+++ b/tests/test_cli_args.py
@@ -86,9 +86,12 @@ EXPECTED_SUBCOMMANDS = [
     'display-text',
     'identify-matrices',
     'bootloader',
+    'controller-info',
     'install-presets',
     'scroll-until',
     'set-presets-dir',
+    'show-presets-dir',
+    'ticket-info',
 ]
 
 
@@ -161,6 +164,14 @@ class TestMatrixSelectionAfterSubcommand:
 
     def test_only_left_after_scroll_until(self):
         ns = _parse(['scroll-until', '-L', 'Loading…', 'sleep 1'])
+        assert ns.only_left is True
+
+    def test_only_right_after_controller_info(self):
+        ns = _parse(['controller-info', '-R'])
+        assert ns.only_right is True
+
+    def test_only_left_after_ticket_info(self):
+        ns = _parse(['ticket-info', '-L'])
         assert ns.only_left is True
 
 
@@ -277,3 +288,51 @@ class TestSetPresetsDirArgs:
     def test_path_captured(self):
         ns = _parse(['set-presets-dir', '/custom/presets'])
         assert ns.path == '/custom/presets'
+
+
+class TestControllerInfoArgs:
+    def test_no_firmware_flag(self):
+        ns = _parse(['controller-info', '--no-firmware'])
+        assert ns.no_firmware is True
+
+
+class TestTicketInfoArgs:
+    def test_copy_flag(self):
+        ns = _parse(['ticket-info', '--copy'])
+        assert ns.copy is True
+
+    def test_copy_format_markdown(self):
+        ns = _parse(['ticket-info', '--copy-format', 'markdown'])
+        assert ns.copy_format == 'markdown'
+
+    def test_no_update_check_flag(self):
+        ns = _parse(['ticket-info', '--no-update-check'])
+        assert ns.no_update_check is True
+
+
+class TestVersionFlags:
+    def test_version_flag_prints_and_exits(self, monkeypatch, capsys):
+        monkeypatch.setattr(
+            'is_matrix_forge.led_matrix.Scripts.led_matrix.arguments.build_version_output',
+            lambda check_updates=False: 'version-output',
+        )
+
+        args = Arguments()
+        with pytest.raises(SystemExit) as excinfo:
+            args.parse_args(['-V'])
+
+        assert excinfo.value.code == 0
+        assert capsys.readouterr().out == 'version-output\n'
+
+    def test_check_updates_flag_prints_and_exits(self, monkeypatch, capsys):
+        monkeypatch.setattr(
+            'is_matrix_forge.led_matrix.Scripts.led_matrix.arguments.build_version_output',
+            lambda check_updates=False: 'update-output' if check_updates else 'version-output',
+        )
+
+        args = Arguments()
+        with pytest.raises(SystemExit) as excinfo:
+            args.parse_args(['--check-updates'])
+
+        assert excinfo.value.code == 0
+        assert capsys.readouterr().out == 'update-output\n'

--- a/tests/test_cli_support.py
+++ b/tests/test_cli_support.py
@@ -1,0 +1,136 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from is_matrix_forge.led_matrix.Scripts.led_matrix import support
+
+
+class DummyDevice:
+    def __init__(
+        self,
+        *,
+        name="COM7",
+        device="COM7",
+        description="Framework LED Matrix",
+        serial_number="FRAK1234",
+        location="1-3.3:x.4",
+        manufacturer="Framework",
+        product="LED Matrix",
+        hwid="USB VID:PID=32AC:0020",
+        vid=0x32AC,
+        pid=0x20,
+    ):
+        self.name = name
+        self.device = device
+        self.description = description
+        self.serial_number = serial_number
+        self.location = location
+        self.manufacturer = manufacturer
+        self.product = product
+        self.hwid = hwid
+        self.vid = vid
+        self.pid = pid
+
+
+def test_build_controller_info_report_includes_firmware(monkeypatch):
+    monkeypatch.setattr(support, "_query_firmware_version", lambda device: "1.2.3")
+    monkeypatch.setattr(
+        support,
+        "resolve_device_location",
+        lambda device: {"abbrev": "R2", "side": "right", "slot": 2},
+    )
+
+    report = support.build_controller_info_report([DummyDevice()])
+
+    assert "Detected matrices: 1" in report
+    assert "location: R2 (right slot 2)" in report
+    assert "firmware_version: 1.2.3" in report
+
+
+def test_build_version_output_shows_update_message(monkeypatch):
+    monkeypatch.setattr(
+        support,
+        "get_version_snapshot",
+        lambda: {
+            "package_name": "IS-Matrix-Forge",
+            "display_version": "1.0.0-dev.29",
+            "source_version": "1.0.0-dev.29",
+            "installed_version": "1.0.0.dev28",
+        },
+    )
+    monkeypatch.setattr(
+        support,
+        "safe_check_for_updates",
+        lambda timeout=3.0: {"message": "Update available on PyPI: 1.0.0.dev30."},
+    )
+
+    output = support.build_version_output(check_updates=True)
+
+    assert "IS-Matrix-Forge 1.0.0-dev.29" in output
+    assert "Installed distribution version: 1.0.0.dev28" in output
+    assert "Update available on PyPI: 1.0.0.dev30." in output
+
+
+def test_build_ticket_info_report_includes_selection_and_copyable_sections(monkeypatch):
+    monkeypatch.setattr(
+        support,
+        "get_version_snapshot",
+        lambda: {
+            "package_name": "IS-Matrix-Forge",
+            "display_version": "1.0.0-dev.29",
+            "source_version": "1.0.0-dev.29",
+            "installed_version": "1.0.0.dev28",
+        },
+    )
+    monkeypatch.setattr(support, "get_devices", lambda: [DummyDevice()])
+    monkeypatch.setattr(
+        support,
+        "resolve_device_location",
+        lambda device: {"abbrev": "L1", "side": "left", "slot": 1},
+    )
+    monkeypatch.setattr(
+        support,
+        "safe_check_for_updates",
+        lambda timeout=3.0: {"message": "PyPI is up to date for the installed distribution (latest: 1.0.0.dev28)."},
+    )
+    monkeypatch.setattr(support, "_query_firmware_version", lambda device: "1.2.3")
+
+    args = SimpleNamespace(only_left=True, only_right=False)
+    report = support.build_ticket_info_report(args)
+
+    assert "IS-Matrix-Forge Ticket Info" in report
+    assert "Matrix selection: the leftmost LED matrix" in report
+    assert "Update check: PyPI is up to date for the installed distribution" in report
+    assert "firmware_version: 1.2.3" in report
+
+
+def test_build_ticket_info_markdown_report(monkeypatch):
+    monkeypatch.setattr(
+        support,
+        "get_version_snapshot",
+        lambda: {
+            "package_name": "IS-Matrix-Forge",
+            "display_version": "1.0.0-dev.29",
+            "source_version": "1.0.0-dev.29",
+            "installed_version": "1.0.0.dev28",
+        },
+    )
+    monkeypatch.setattr(support, "get_devices", lambda: [DummyDevice()])
+    monkeypatch.setattr(
+        support,
+        "resolve_device_location",
+        lambda device: {"abbrev": "R1", "side": "right", "slot": 1},
+    )
+    monkeypatch.setattr(
+        support,
+        "safe_check_for_updates",
+        lambda timeout=3.0: {"message": "Update available on PyPI: 1.0.0.dev30."},
+    )
+    monkeypatch.setattr(support, "_query_firmware_version", lambda device: "1.2.3")
+
+    report = support.build_ticket_info_report(format="markdown")
+
+    assert report.startswith("# IS-Matrix-Forge Ticket Info")
+    assert "- **Update check:** Update available on PyPI: 1.0.0.dev30." in report
+    assert "### Matrix 1" in report
+    assert "- **firmware_version:** 1.2.3" in report

--- a/tests/test_cli_support.py
+++ b/tests/test_cli_support.py
@@ -147,6 +147,7 @@ def test_safe_check_for_updates_reports_source_tree_newer_than_pypi(monkeypatch)
             self.latest = "1.0.0.dev28"
             self.installed = "1.0.0.dev28"
             self.newer_available_version = None
+            self.installed_newer_than_latest = False
 
         def check_for_update(self):
             return False
@@ -172,3 +173,40 @@ def test_safe_check_for_updates_reports_source_tree_newer_than_pypi(monkeypatch)
     assert result["status"] == "local-newer-than-pypi"
     assert "Installed distribution matches the latest PyPI release (1.0.0.dev28)." in result["message"]
     assert "Current source tree version 1.0.0-dev.29 is newer than the latest PyPI release 1.0.0.dev28." in result["message"]
+
+
+def test_safe_check_for_updates_uses_installed_newer_than_latest(monkeypatch):
+    class FakePyPiVersionInfo:
+        def __init__(self, package_name, include_pre_release_for_update_check=False):
+            self.package_name = package_name
+            self.include_pre_release_for_update_check = include_pre_release_for_update_check
+            self.latest_pre_release = "1.0.0.dev28"
+            self.latest_stable = "1.0.0.dev27"
+            self.latest = "1.0.0.dev28"
+            self.installed = "1.0.0.dev29"
+            self.newer_available_version = None
+            self.installed_newer_than_latest = True
+
+        def check_for_update(self):
+            return False
+
+    monkeypatch.setattr(
+        support,
+        "get_version_snapshot",
+        lambda: {
+            "package_name": "IS-Matrix-Forge",
+            "display_version": "1.0.0-dev.29",
+            "source_version": "1.0.0-dev.29",
+            "installed_version": "1.0.0.dev29",
+        },
+    )
+    monkeypatch.setattr(support, "_pypi_request_timeout", lambda timeout: contextlib.nullcontext())
+
+    import inspyre_toolbox.ver_man as ver_man
+
+    monkeypatch.setattr(ver_man, "PyPiVersionInfo", FakePyPiVersionInfo)
+
+    result = support.safe_check_for_updates()
+
+    assert result["status"] == "local-newer-than-pypi"
+    assert "Installed distribution version 1.0.0.dev29 is newer than the latest PyPI release 1.0.0.dev28." in result["message"]

--- a/tests/test_cli_support.py
+++ b/tests/test_cli_support.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import contextlib
 from types import SimpleNamespace
 
 from is_matrix_forge.led_matrix.Scripts.led_matrix import support
@@ -134,3 +135,40 @@ def test_build_ticket_info_markdown_report(monkeypatch):
     assert "- **Update check:** Update available on PyPI: 1.0.0.dev30." in report
     assert "### Matrix 1" in report
     assert "- **firmware_version:** 1.2.3" in report
+
+
+def test_safe_check_for_updates_reports_source_tree_newer_than_pypi(monkeypatch):
+    class FakePyPiVersionInfo:
+        def __init__(self, package_name, include_pre_release_for_update_check=False):
+            self.package_name = package_name
+            self.include_pre_release_for_update_check = include_pre_release_for_update_check
+            self.latest_pre_release = "1.0.0.dev28"
+            self.latest_stable = "1.0.0.dev27"
+            self.latest = "1.0.0.dev28"
+            self.installed = "1.0.0.dev28"
+            self.newer_available_version = None
+
+        def check_for_update(self):
+            return False
+
+    monkeypatch.setattr(
+        support,
+        "get_version_snapshot",
+        lambda: {
+            "package_name": "IS-Matrix-Forge",
+            "display_version": "1.0.0-dev.29",
+            "source_version": "1.0.0-dev.29",
+            "installed_version": "1.0.0.dev28",
+        },
+    )
+    monkeypatch.setattr(support, "_pypi_request_timeout", lambda timeout: contextlib.nullcontext())
+
+    import inspyre_toolbox.ver_man as ver_man
+
+    monkeypatch.setattr(ver_man, "PyPiVersionInfo", FakePyPiVersionInfo)
+
+    result = support.safe_check_for_updates()
+
+    assert result["status"] == "local-newer-than-pypi"
+    assert "Installed distribution matches the latest PyPI release (1.0.0.dev28)." in result["message"]
+    assert "Current source tree version 1.0.0-dev.29 is newer than the latest PyPI release 1.0.0.dev28." in result["message"]

--- a/tests/test_repository_identity.py
+++ b/tests/test_repository_identity.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+THIS_FILE = Path(__file__).resolve()
+TEXT_SUFFIXES = {".md", ".py", ".toml", ".json", ".yml", ".yaml", ".txt"}
+BANNED_SNIPPETS = (
+    "Inspyre-Softworks/led-matrix-battery",
+    "led-matrix-battery",
+    "grew out of the LED Matrix project",
+)
+
+
+def _tracked_text_files() -> list[Path]:
+    results = []
+    for path in ROOT.rglob("*"):
+        if not path.is_file():
+            continue
+        if ".git" in path.parts:
+            continue
+        if "__pycache__" in path.parts:
+            continue
+        if path.resolve() == THIS_FILE:
+            continue
+        if path.suffix.lower() in TEXT_SUFFIXES:
+            results.append(path)
+    return results
+
+
+def test_tracked_files_do_not_reference_the_old_project_identity():
+    offenders: list[str] = []
+
+    for path in _tracked_text_files():
+        text = path.read_text(encoding="utf-8", errors="ignore")
+        for snippet in BANNED_SNIPPETS:
+            if snippet in text:
+                offenders.append(f"{path.relative_to(ROOT)} -> {snippet}")
+
+    assert not offenders, "Old project references remain in tracked files:\n" + "\n".join(offenders)


### PR DESCRIPTION
## Summary
- Add `-V` version output plus a PyPI update check that fails gracefully when network access is unavailable
- Add debug-oriented CLI commands for controller info, bootloader access, and support ticket collection
- Support copying ticket info as plaintext or Markdown, including device metadata and optional firmware details
- Cover the new CLI flags and report builders with parser and unit tests

## Testing
- `poetry run pytest -q` passed
- Added focused tests for the new CLI arguments, version/update behavior, and ticket report formatting

## Summary by Sourcery

Add new CLI capabilities for version reporting, debugging, and ticket support, along with supporting utilities and tests.

New Features:
- Add global -V/--version and --check-updates flags to report package versions and optionally check PyPI for newer releases.
- Introduce controller-info and ticket-info subcommands to inspect connected matrices and generate support-friendly reports, including optional clipboard copying and Markdown output.
- Add a reusable support module for device selection, controller info reporting, version/update checks, and ticket report generation.

Enhancements:
- Update the bootloader command to operate on the same device selection logic as other matrix-aware commands.
- Refine project README wording to align with the Matrix Forge branding and positioning.

Build:
- Bump the project version in pyproject.toml to 1.0.0-dev.30.

Documentation:
- Update the bug report issue template to instruct users to attach led-matrix ticket-info output for easier debugging.

Tests:
- Extend CLI argument parsing tests to cover controller-info, ticket-info, and version/update flags.
- Add unit tests for support utilities including controller info reports, ticket info reports, and PyPI update checking behavior.
- Add a repository identity test to ensure legacy project references are not present in tracked text files.