### PR TITLE
Add Read the Docs setup and finalize documentation navigation

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,14 @@
+version: 2
+
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.12"
+
+sphinx:
+  configuration: docs/conf.py
+  fail_on_warning: false
+
+python:
+  install:
+    - requirements: docs/requirements.txt

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,0 +1,23 @@
+"""Sphinx configuration for IS Matrix Forge documentation."""
+
+from __future__ import annotations
+
+project = "IS Matrix Forge"
+author = "Inspyre Softworks"
+copyright = "2026, Inspyre Softworks"
+
+extensions = [
+    "myst_parser",
+]
+
+templates_path = ["_templates"]
+exclude_patterns = ["_build", "Thumbs.db", ".DS_Store"]
+
+source_suffix = {
+    ".rst": "restructuredtext",
+    ".md": "markdown",
+}
+
+master_doc = "index"
+
+html_theme = "alabaster"

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,0 +1,57 @@
+# Getting Started
+
+## What You Need
+
+- Python 3.12 or newer
+- A supported 9×34 LED matrix connected over USB
+- Hardware identifiers:
+  - VID: `0x32AC`
+  - PID: `0x20`
+  - Serial number prefix: `FRAK`
+
+## Installation
+
+### Option 1: Poetry (recommended for contributors)
+
+```bash
+git clone https://github.com/Inspyre-Softworks/IS-Matrix-Forge.git
+cd IS-Matrix-Forge
+poetry install
+poetry shell
+```
+
+### Option 2: pip
+
+```bash
+git clone https://github.com/Inspyre-Softworks/IS-Matrix-Forge.git
+cd IS-Matrix-Forge
+pip install .
+```
+
+## First Device Check
+
+Use the helper to list discovered devices:
+
+```python
+from is_matrix_forge.led_matrix.helpers.device import DEVICES
+
+for dev in DEVICES:
+    print(dev)
+```
+
+## First Output
+
+Display scrolling text on the first connected device:
+
+```python
+from is_matrix_forge.led_matrix.controller.controller import LEDMatrixController
+from is_matrix_forge.led_matrix.helpers.device import DEVICES
+
+controller = LEDMatrixController(DEVICES[0])
+controller.scroll_text("Hello World!", loop=False)
+```
+
+## Next Steps
+
+- Read the full [User Manual](user_manual.md)
+- Review architecture guidance in [Contributing: Controller Mixins](contributing-mixins.md)

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,14 @@
+# IS Matrix Forge Documentation
+
+IS Matrix Forge is a Python framework for creating applications that drive 9×34
+LED matrix displays.
+
+```{toctree}
+:maxdepth: 2
+:caption: Contents
+
+getting-started
+user_manual
+contributing-mixins
+adr/0001-controller-mro-and-cooperative-init
+```

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,0 +1,2 @@
+sphinx>=7.4,<9.0
+myst-parser>=3.0,<5.0

--- a/docs/user_manual.md
+++ b/docs/user_manual.md
@@ -1,11 +1,11 @@
 # IS Matrix Forge - User Manual
 
 ## Table of Contents
-1. [Introduction](#introduction)
-2. [Hardware Setup](#hardware-setup)
-3. [Software Installation](#software-installation)
-4. [Using the Features](#using-the-features)
-5. [Troubleshooting](#troubleshooting)
+1. Introduction
+2. Hardware Setup
+3. Software Installation
+4. Using the Features
+5. Troubleshooting
 
 ## Introduction
 


### PR DESCRIPTION
This pull request sets up the documentation system for IS Matrix Forge using Sphinx and MyST, and adds initial user and contributor documentation. The main changes establish the configuration for Read the Docs, add Sphinx and MyST dependencies, provide a Sphinx configuration, and include starter documentation files.

Documentation infrastructure:

* Added `.readthedocs.yaml` to configure Read the Docs builds with Python 3.12 and Sphinx, specifying dependencies in `docs/requirements.txt`.
* Added `docs/requirements.txt` with Sphinx and myst-parser as dependencies for building the documentation.
* Added `docs/conf.py` to configure Sphinx, enabling MyST Markdown support, setting project metadata, and specifying theme and source file types.

Documentation content:

* Added `docs/index.md` as the main documentation landing page, with a table of contents linking to getting started, user manual, and contributing guides.
* Added `docs/getting-started.md` with instructions for installation, device discovery, and displaying text on the LED matrix.
* Updated `docs/user_manual.md` to improve the table of contents formatting.

## Summary by Sourcery

Set up Sphinx-based documentation and Read the Docs configuration for IS Matrix Forge and add initial getting started and navigation structure.

New Features:
- Introduce a Sphinx documentation site with a Markdown-based index page and table of contents.
- Add a Getting Started guide covering installation, device discovery, and basic LED matrix usage.

Enhancements:
- Simplify the user manual table of contents formatting for better readability.

Build:
- Add a Read the Docs configuration targeting Python 3.12 and pointing to the Sphinx docs configuration.
- Add documentation build requirements including Sphinx and MyST parser.
- Add Sphinx configuration enabling MyST Markdown support and specifying HTML theme and source file types.